### PR TITLE
Add structured selected site output

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,10 @@ Note that the word the word "gene" is used here to refer to the genomic componen
 * `--use_existing_preprocess`: Use existing preprocess folder and skip running the preprocess step.
 * `--use_default_gp`: Don't replace group penalties (automatically set to True if the group_penalty_type is "std").
 * `--keep_raw_output`: Don't delete the raw model output files for each run. The raw models can be found in the preprocessed_data_and_outputs directory. You can also set a new directory by using the `--esl_inputs_outputs_dir` argument, but note that any files ending in .txt will be cleared from this directory before each ESL-PSC run.
-* `--show_selected_sites`: Print a dictionary of all selected sites with their highest model score for every gene in the gene_ranks output file.
+* `--show_selected_sites`: Include the top-scoring sites for each gene. When
+  enabled, the gene ranks file gains a `num_selected_sites` column and a
+  separate `<output_name>_selected_sites.csv` file lists each site with its GSS
+  score.
 * `--no_genes_output`: Don't output a gene ranks file. If only predictions output is desired, including the option will speed up the analysis.
 * `--no_pred_output`: Don't output a species predictions file. If only gene ranks output is desired, including the option will significantly speed up the analysis.
 * `--make_sps_plot`: Make a violin plot showing SPS density for each true phenotype (SPS of > 1 or < -1 as 1 and -1 by default).

--- a/esl_psc_cli/esl_multimatrix.py
+++ b/esl_psc_cli/esl_multimatrix.py
@@ -501,11 +501,16 @@ def main(raw_args=None):
           args.canceled_alignments_dir)
     
     # call output functions which should generate output files
-    if not args.no_genes_output: # skip genes output if flag is true
+    if not args.no_genes_output:  # skip genes output if flag is true
         esl_int.generate_gene_ranks_output(gene_objects_dict, args.output_dir,
                                       args.output_file_base_name,
-                                      show_sites = args.show_selected_sites,
-                                           multimatrix = True)
+                                      show_sites=args.show_selected_sites,
+                                      multimatrix=True)
+        if args.show_selected_sites:
+            esl_int.generate_selected_sites_output(gene_objects_dict,
+                                                  args.output_dir,
+                                                  args.output_file_base_name,
+                                                  multimatrix=True)
     print('\n')
     if not args.no_pred_output: # skip this output if flag is true
         # make full file path of output predictions file

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -4,27 +4,22 @@ import subprocess
 import sys
 from pathlib import Path
 
+
 def test_demo_run_smoke(tmp_path):
-    """
-    Runs the full CLI script with the demo data and checks for success.
-    This acts as a high-level integration smoke test.
-    """
-    # 1. Define paths relative to the project root
+    """Runs the CLI on the demo data and checks that output files are created."""
     project_root = Path(__file__).parent.parent
     alignments_dir = project_root / "photosynthesis_alignments"
     species_groups_file = project_root / "photo_single_LC_matrix_species_groups.txt"
     species_pheno_file = project_root / "photo_species_phenotypes.txt"
-    
-    # Ensure the required demo data exists before running the test
+
     assert alignments_dir.exists(), "Demo alignments directory not found!"
     assert species_groups_file.exists(), "Demo species groups file not found!"
 
-    # 2. Construct the command arguments for the CLI script
     output_basename = "smoke_test_output"
     output_dir = tmp_path
-    
+
     command = [
-        sys.executable,  # Use the same python interpreter that's running the test
+        sys.executable,
         "-m", "esl_multimatrix",
         "--alignments_dir", str(alignments_dir),
         "--species_groups_file", str(species_groups_file),
@@ -32,25 +27,26 @@ def test_demo_run_smoke(tmp_path):
         "--output_file_base_name", output_basename,
         "--output_dir", str(output_dir),
         "--use_logspace",
-        "--num_log_points", "4",  # Use a small number for a fast test
+        "--num_log_points", "4",
+        "--show_selected_sites",
     ]
 
-    # 3. Run the script as a subprocess
     print(f"\nRunning command: {' '.join(command)}")
     result = subprocess.run(command, capture_output=True, text=True)
 
-    # 4. Assert the results
-    # Assert that the script completed successfully (exit code 0)
-    assert result.returncode == 0, f"Script failed with exit code {result.returncode}\nStderr:\n{result.stderr}"
+    assert result.returncode == 0, (
+        f"Script failed with exit code {result.returncode}\nStderr:\n{result.stderr}"
+    )
 
-    # Assert that the expected output files were created
     expected_predictions_file = output_dir / f"{output_basename}_species_predictions.csv"
     expected_ranks_file = output_dir / f"{output_basename}_gene_ranks.csv"
-    
+    expected_sites_file = output_dir / f"{output_basename}_selected_sites.csv"
+
     assert expected_predictions_file.exists(), "Predictions output file was not created."
     assert expected_ranks_file.exists(), "Gene ranks output file was not created."
+    assert expected_sites_file.exists(), "Selected sites output file was not created."
 
-    # Optional: A more detailed check to ensure the file is not empty
     assert expected_ranks_file.stat().st_size > 0, "Gene ranks file is empty."
-    
+    assert expected_sites_file.stat().st_size > 0, "Selected sites file is empty."
+
     print("Smoke test passed: Script ran successfully and created output files.")


### PR DESCRIPTION
## Summary
- add a `--show_selected_sites` documentation update
- output selected sites to `<basename>_selected_sites.csv`
- call new output function from integration scripts
- update CLI smoke test to check for new file

## Testing
- `flake8 --select=F --exclude additional_code .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685721e917b88327b461fd9e72d7c851