### PR TITLE
Improve GUI selected site display

### DIFF
--- a/gui/ui/widgets/__init__.py
+++ b/gui/ui/widgets/__init__.py
@@ -2,4 +2,4 @@
 Custom widgets for the ESL-PSC GUI.
 """
 
-__all__ = ['file_selectors', 'parameter_inputs']
+__all__ = ['file_selectors', 'parameter_inputs', 'protein_map']

--- a/gui/ui/widgets/protein_map.py
+++ b/gui/ui/widgets/protein_map.py
@@ -1,0 +1,25 @@
+from PyQt6.QtWidgets import QWidget
+from PyQt6.QtGui import QPainter, QColor, QPen
+
+
+class ProteinMapWidget(QWidget):
+    """Simple schematic showing selected site positions on a protein."""
+
+    def __init__(self, length: int, sites: list[int], parent=None):
+        super().__init__(parent)
+        self.length = max(length, 1)
+        self.sites = sites
+        self.setMinimumHeight(20)
+        self.setMaximumHeight(20)
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        bar_height = 6
+        y = (self.height() - bar_height) // 2
+        painter.fillRect(0, y, self.width(), bar_height, QColor(220, 220, 220))
+        pen = QPen(QColor("green"))
+        for site in self.sites:
+            x = int(site / self.length * self.width())
+            painter.setPen(pen)
+            painter.drawLine(x, y, x, y + bar_height)
+        painter.end()


### PR DESCRIPTION
## Summary
- move results buttons above progress bars in RunPage
- add ProteinMapWidget to visualize selected site positions
- show selected sites grouped by gene with expandable tables

## Testing
- `flake8 --select=F --exclude additional_code .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68575ae1d99083279c47dd5a43144c1f