### PR TITLE
Improve gene rank dialog

### DIFF
--- a/gui/ui/pages/run_page.py
+++ b/gui/ui/pages/run_page.py
@@ -12,7 +12,7 @@ from PyQt6.QtWidgets import (
 from gui.core.worker import ESLWorker
 from .base_page import BaseWizardPage
 from gui.ui.widgets.results_display import (
-    SpsPlotDialog, GeneRanksDialog, SelectedSitesDialog
+    SpsPlotDialog, GeneRanksDialog
 )
 
 class RunPage(BaseWizardPage):
@@ -64,13 +64,9 @@ class RunPage(BaseWizardPage):
         self.gene_btn = QPushButton("Show Top Gene Ranks")
         self.gene_btn.hide()
         self.gene_btn.clicked.connect(self.show_gene_ranks)
-        self.sites_btn = QPushButton("Show Selected Sites")
-        self.sites_btn.hide()
-        self.sites_btn.clicked.connect(self.show_selected_sites)
         self.results_layout.addStretch()
         self.results_layout.addWidget(self.sps_btn)
         self.results_layout.addWidget(self.gene_btn)
-        self.results_layout.addWidget(self.sites_btn)
         container_layout.addLayout(self.results_layout)
 
         # Progress Bars GroupBox
@@ -188,7 +184,6 @@ class RunPage(BaseWizardPage):
             self.step_status_label.setText("Starting analysis...")
             self.sps_btn.hide()
             self.gene_btn.hide()
-            self.sites_btn.hide()
             self.sps_plot_path = None
             self.gene_ranks_path = None
             self.selected_sites_path = None
@@ -257,18 +252,6 @@ class RunPage(BaseWizardPage):
         else:
             QMessageBox.warning(self, "File Not Found", "The gene ranks file could not be found.")
 
-    def show_selected_sites(self):
-        """Slot to show the selected sites table if available."""
-        if self.selected_sites_path and os.path.exists(self.selected_sites_path):
-            alignments_dir = getattr(self.config, "alignments_dir", "")
-            SelectedSitesDialog.show_dialog(
-                self.selected_sites_path,
-                self.gene_ranks_path,
-                alignments_dir,
-                parent=self,
-            )
-        else:
-            QMessageBox.warning(self, "File Not Found", "The selected sites file could not be found.")
 
     def analysis_finished(self, exit_code):
         """Handle analysis completion."""
@@ -307,10 +290,8 @@ class RunPage(BaseWizardPage):
                 self.gene_btn.show()
 
             sites_path = os.path.abspath(os.path.join(out_dir, f"{base}_selected_sites.csv"))
-            # Only show the button if selected-sites output was generated for this run
             if getattr(self.config, "show_selected_sites", False) and os.path.exists(sites_path):
                 self.selected_sites_path = sites_path
-                self.sites_btn.show()
         elif exit_code == -1 or (self.worker and self.worker.was_stopped):
             self.step_status_label.setText("Analysis stopped by user.")
             self.append_error("\n🛑 Analysis was stopped.")

--- a/gui/ui/widgets/site_viewer.py
+++ b/gui/ui/widgets/site_viewer.py
@@ -10,8 +10,8 @@ from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QColor, QBrush, QFont
 from PyQt6.QtWidgets import (
     QTableWidget, QTableWidgetItem, QWidget, QVBoxLayout, QHBoxLayout,
-    QSplitter, QSlider, QComboBox, QLabel, QPushButton, QRadioButton,
-    QButtonGroup, QCheckBox, QAbstractItemView, QMessageBox, QMenu
+    QSplitter, QSlider, QComboBox, QLabel, QPushButton,
+    QCheckBox, QAbstractItemView, QMessageBox, QMenu
 )
 
 # point to your shared constants and canvas
@@ -552,8 +552,6 @@ class SiteViewer(QWidget):
         Singletons (non-gap) in Convergent+Control are replaced by '?'.
         Each gap ('-') in Convergent or Control reduces the score by 1.
         """
-        from collections import Counter
-
         conv_indices = [self.species_ids.index(sp) for sp in self.convergent_species if sp in self.species_ids]
         ctrl_indices = [self.species_ids.index(sp) for sp in self.control_species if sp in self.species_ids]
         out_indices  = [self.species_ids.index(sp) for sp in self.outgroup_species if sp in self.species_ids]
@@ -612,7 +610,6 @@ class SiteViewer(QWidget):
                     list(set(clean_ctrl))[0] == list(set(clean_out))[0]
                 ):
                     ctrl_res = clean_ctrl[0]
-                    from collections import Counter
                     conv_counter = Counter(clean_conv)
                     for res, cnt in conv_counter.items():
                         if res != ctrl_res and cnt >= 2:
@@ -628,7 +625,6 @@ class SiteViewer(QWidget):
                     out_res = clean_out[0]
                     # All convergent match out_res
                     if clean_conv and all(r == out_res for r in clean_conv):
-                        from collections import Counter
                         ctrl_counter = Counter(clean_ctrl)
                         for res, cnt in ctrl_counter.items():
                             if res != out_res and cnt >= 2:
@@ -725,7 +721,6 @@ class SiteViewer(QWidget):
             conv_label_row = row_idx
             row_idx += 1 + conv_size
 
-        blank_after_conv = row_idx
         if conv_label_row:
             row_idx += 1
 
@@ -734,7 +729,6 @@ class SiteViewer(QWidget):
             ctrl_label_row = row_idx
             row_idx += 1 + ctrl_size
 
-        blank_after_ctrl = row_idx
         if ctrl_label_row:
             row_idx += 1
 


### PR DESCRIPTION
## Summary
- combine selected-sites data into gene ranks table
- streamline results buttons in the run page
- fix lint issues in SiteViewer

## Testing
- `flake8 --select=F --exclude additional_code .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685873c6a46483279cc3fe2201222023