### PR TITLE
Fix unwanted Matplotlib warnings in GUI density plots

### DIFF
--- a/esl_psc_cli/esl_psc_functions.py
+++ b/esl_psc_cli/esl_psc_functions.py
@@ -422,8 +422,8 @@ def run_preprocess(esl_dir_path, response_matrix_file_path, path_file_path,
 def rmse_range_pred_plots(pred_csv_path, title, pheno_names = None,
                           min_genes = 0, plot_type = 'violin'):
     '''calls sps_density.create_sps_plot for each of a series of RMSE ranks.
-    pheno_names is a tuple with the +1 pheno name first and the -1 pheno 2nd,
-    or if it isn't given the defaults will be used.  plot type can be 'kde' or
+    pheno_names is a tuple with the +1 phenotype name first and the -1 phenotype second.
+    If not provided, the defaults "Positive" and "Negative" will be used. Plot type can be 'kde' or
     violin (violin will assign anything > 1 or < -1 to 1 and -1 respectively
     by default to make it easier to see the region of overlap.
     '''
@@ -457,7 +457,7 @@ def rmse_range_pred_plots(pred_csv_path, title, pheno_names = None,
     fig_path = os.path.join(os.path.split(pred_csv_path)[0],
                             title + '_pred_sps_plot.svg')
     if not pheno_names: # set phenotype names
-        pheno_names = (1, -1)
+        pheno_names = ("Positive", "Negative")
     pos_pheno_name = pheno_names[0]
     neg_pheno_name = pheno_names[1]
         

--- a/esl_psc_cli/sps_density.py
+++ b/esl_psc_cli/sps_density.py
@@ -16,15 +16,15 @@ def create_sps_plot(csv_file_path=None,
                     bw_method = 0.07,
                     fig_path = 'plot.png',
                     title = 'Model Predictions',
-                    neg_pheno_name = -1,
-                    pos_pheno_name = 1,
+                    neg_pheno_name = "Negative",
+                    pos_pheno_name = "Positive",
                     neg_pheno_color = '#F55E54',
                     pos_pheno_color = '#2fc8cc',
                     percent_accuracy = True,
                     axes = None,
                     min_genes = 0):
     '''creates density plot of sequence prediction score for each species in each ESL run 
-    plot has two lines: 1 corresponds to negative phenotype (-1), 1 to positive phenotype (1)
+    plot has two lines: one for the negative phenotype and one for the positive phenotype
     can either pass csv file or dataframe but not both
     required columns in data: SPS values, true phenotype, input RMSE
     
@@ -95,8 +95,8 @@ def create_sps_plot_violin(csv_file_path=None,
                     bw_method = 0.2,
                     fig_path = 'plot.png',
                     title = 'Model Predictions',
-                    neg_pheno_name = -1,
-                    pos_pheno_name = 1,
+                    neg_pheno_name = "Negative",
+                    pos_pheno_name = "Positive",
                     neg_pheno_color = '#F55E54',
                     pos_pheno_color = '#2fc8cc',
                     percent_accuracy = True,


### PR DESCRIPTION
## Summary
- update default phenotype labels to strings instead of numeric values
- adjust rmse_range_pred_plots to use the new defaults
- clarify related docstrings

## Testing
- `flake8 --select=F --exclude additional_code .`
- `pytest -q` *(fails: KeyboardInterrupt after ~5 min)*

------
https://chatgpt.com/codex/tasks/task_b_6858ce80d6a88327942b71b883a40871