### PR TITLE
Enhance tree viewer

### DIFF
--- a/gui/ui/pages/input_page.py
+++ b/gui/ui/pages/input_page.py
@@ -227,7 +227,28 @@ class InputPage(BaseWizardPage):
             )
             return
 
-        self._tree_window = TreeViewer(tree)
+        phenos = {}
+        pheno_path = getattr(self.config, "species_phenotypes_file", "")
+        if pheno_path and os.path.exists(pheno_path):
+            try:
+                import csv
+
+                with open(pheno_path, newline="") as f:
+                    reader = csv.reader(f)
+                    for row in reader:
+                        if len(row) >= 2:
+                            try:
+                                phenos[row[0].strip()] = int(row[1])
+                            except ValueError:
+                                continue
+            except Exception as exc:
+                QMessageBox.warning(
+                    self,
+                    "Phenotypes Error",
+                    f"Failed to parse phenotypes file:\n{exc}",
+                )
+
+        self._tree_window = TreeViewer(tree, phenotypes=phenos)
         self._tree_window.show()
 
     # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- allow coloring species in tree viewer based on phenotype file
- add legend explaining colors
- expand graphics scene to avoid truncating labels when panning/zooming
- parse phenotype CSV in input page and pass to the tree viewer

## Testing
- `flake8 --select=F --exclude additional_code .`
- `pytest -q tests/test_gui_smoke.py`
- `pytest -q tests/test_cli_smoke.py::test_demo_run_smoke` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_b_68644fd261148327b76e525c8d7b3d11