### PR TITLE
Improve tree viewer usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Note that the word the word "gene" is used here to refer to the genomic componen
 1. photo_single_LC_matrix_species_groups.txt (the grass species with the closest contrast partners with the longest sequences (i.e. fewest gaps; used for photosynthesis analyses in [Allard et al., 2025](https://doi.org/10.1038/s41467-025-58428-8)))
 2. orthomam_echo_species_groups.txt (this can be used to reproduce the echolocation analyses using all 16 species combinations ([Allard et al., 2025](https://doi.org/10.1038/s41467-025-58428-8))) 
 
-A species phenotype file for the grass species has also been included: photo_species_phenotypes.txt
+A species phenotype file for the grass species has also been included: photo_species_phenotypes_full.txt
 
 #### We have included the protein sequence alignments used for ESL-PSC analyses by Allard et al. (2025). If you use these data, please cite these sources: ####
 
@@ -236,7 +236,7 @@ You can run an ESL-PSC analysis of the C3/C4 trait with the included chloroplast
 1. Clone this repository
 2. Make sure you have the dependencies installed (see [Installation and Dependncies](#installation-and-dependncies) above). You will need 
 3. Navigate to the `ESL_PSC/` directory on your computer
-4. Run this command from the ESL-PSC directory: `python esl_multimatrix.py --output_file_base_name demo_output --species_groups_file photo_single_LC_matrix_species_groups.txt --alignments_dir photosynthesis_alignments/ --use_logspace --num_log_points 20 --cancel_only_partner --species_pheno_path photo_species_phenotypes.txt --make_sps_plot --pheno_names "C4" "C3"`
+4. Run this command from the ESL-PSC directory: `python esl_multimatrix.py --output_file_base_name demo_output --species_groups_file photo_single_LC_matrix_species_groups.txt --alignments_dir photosynthesis_alignments/ --use_logspace --num_log_points 20 --cancel_only_partner --species_pheno_path photo_species_phenotypes_full.txt --make_sps_plot --pheno_names "C4" "C3"`
 5. The expected run time is approximately 30 seconds on a standard desktop computer.
 6. A set of violin plots depeicting the prediction scores for C3 and C4 species will be displayed on the screen. The gene ranks (`demo_output_gene_ranks.csv`) and species prediction (`demo_output_species_predictions.csv`) csv files will be found in the ESL_PSC directory
 the plot should look like this:

--- a/demo_config_for_gui.json
+++ b/demo_config_for_gui.json
@@ -1,7 +1,7 @@
 {
   "alignments_dir": "photosynthesis_alignments",
   "species_groups_file": "photo_single_LC_matrix_species_groups.txt",
-  "species_phenotypes_file": "photo_species_phenotypes.txt",
+  "species_phenotypes_file": "photo_species_phenotypes_full.txt",
   "prediction_alignments_dir": "",
   "limited_genes_file": "",
   "response_dir": "",

--- a/gui/ui/pages/input_page.py
+++ b/gui/ui/pages/input_page.py
@@ -248,8 +248,16 @@ class InputPage(BaseWizardPage):
                     f"Failed to parse phenotypes file:\n{exc}",
                 )
 
-        self._tree_window = TreeViewer(tree, phenotypes=phenos)
+        self._tree_window = TreeViewer(
+            tree,
+            phenotypes=phenos,
+            on_pheno_changed=self._update_phenotype_file,
+        )
         self._tree_window.show()
+
+    def _update_phenotype_file(self, path: str) -> None:
+        """Update the phenotype file selector and config."""
+        self.species_phenotypes.set_path(path)
 
     # ──────────────────────────────────────────────────────────────────────────
     # Public helpers for wizard

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -10,7 +10,7 @@ def test_demo_run_smoke(tmp_path):
     project_root = Path(__file__).parent.parent
     alignments_dir = project_root / "photosynthesis_alignments"
     species_groups_file = project_root / "photo_single_LC_matrix_species_groups.txt"
-    species_pheno_file = project_root / "photo_species_phenotypes.txt"
+    species_pheno_file = project_root / "photo_species_phenotypes_full.txt"
 
     assert alignments_dir.exists(), "Demo alignments directory not found!"
     assert species_groups_file.exists(), "Demo species groups file not found!"


### PR DESCRIPTION
## Summary
- enlarge and auto-fit the tree viewer window
- allow loading phenotype files directly in the viewer
- sync phenotype file selection with the input page
- reference the existing phenotype example instead of adding a new file

## Testing
- `flake8 --select=F --exclude additional_code .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68645fa5c7d483278af0a372a2fb2123