### PR TITLE
Fix TreeViewer label color initialization

### DIFF
--- a/gui/ui/widgets/tree_viewer.py
+++ b/gui/ui/widgets/tree_viewer.py
@@ -155,8 +155,6 @@ class TreeViewer(QWidget):
         # Branch lines storage must be defined before we compute pen
         self._branch_lines: Dict[Tuple[Clade, Clade | None], List[QGraphicsLineItem]] = {}
 
-        # Determine branch line color based on current palette
-        self._update_line_pen()
 
         # Create phenotype buttons
         pheno_btn = QPushButton("Load Phenotype File")
@@ -255,8 +253,8 @@ class TreeViewer(QWidget):
         self._alt_boxes: List[QGraphicsRectItem] = []
         self._main_boxes: Dict[str, QGraphicsRectItem] = {}
 
-
-
+        # Determine branch line color based on current palette
+        self._update_line_pen()
 
         # Flag to control whether we should auto-fit the view (only on first draw)
         self._initial_draw = True


### PR DESCRIPTION
## Summary
- fix AttributeError on TreeViewer startup by initializing label storage before updating palette-derived colors
- keep label colors synced with the active theme

## Testing
- `flake8 --select=F --exclude additional_code .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686556ae28e88327aeb7b6e6c62a731b