### PR TITLE
Add 2-line FASTA format checks

### DIFF
--- a/esl_psc_cli/deletion_canceler.py
+++ b/esl_psc_cli/deletion_canceler.py
@@ -322,6 +322,9 @@ def main(raw_args=None):
     parser = get_deletion_canceler_args(parser)
 
     args = ecf.parse_args_with_config(parser, raw_args) # checks for args in config file
+
+    # Ensure input alignments are in 2-line FASTA format
+    ecf.validate_alignment_dir_two_line(args.alignments_dir)
     
     # get species lists 
     if args.response_file: 

--- a/esl_psc_cli/esl_integrator.py
+++ b/esl_psc_cli/esl_integrator.py
@@ -439,6 +439,12 @@ if __name__ == '__main__':
 
     args = ecf.parse_args_with_config(parser)
 
+    # Validate that alignments used for input/predictions are 2-line FASTA
+    ecf.validate_alignment_dir_two_line(args.input_alignments_dir)
+    if (args.prediction_alignments_dir
+            and args.prediction_alignments_dir != args.input_alignments_dir):
+        ecf.validate_alignment_dir_two_line(args.prediction_alignments_dir)
+
     # set output_dir
     if not args.output_dir:
         args.output_dir = args.esl_main_dir

--- a/esl_psc_cli/esl_multimatrix.py
+++ b/esl_psc_cli/esl_multimatrix.py
@@ -412,6 +412,14 @@ def main(raw_args=None):
 
     validate_specific_paths(args) #verify that dir and file paths are real
 
+    # Ensure all alignments are in 2-line FASTA format
+    ecf.validate_alignment_dir_two_line(args.alignments_dir)
+    if (args.prediction_alignments_dir
+            and args.prediction_alignments_dir != args.alignments_dir):
+        ecf.validate_alignment_dir_two_line(args.prediction_alignments_dir)
+    if args.use_existing_alignments and args.canceled_alignments_dir:
+        ecf.validate_alignment_dir_two_line(args.canceled_alignments_dir, recursive=True)
+
     # set output_dir
     if not args.output_dir:
         args.output_dir = args.esl_main_dir

--- a/predict_from_saved_models.py
+++ b/predict_from_saved_models.py
@@ -82,6 +82,10 @@ def main():
                     help="RMSE percentile rank cutoff for selecting models in SPS plot")
     args = pa.parse_args()
 
+    # Ensure prediction alignments are 2-line FASTA files
+    from esl_psc_cli.esl_psc_functions import validate_alignment_dir_two_line
+    validate_alignment_dir_two_line(args.prediction_alignments_dir)
+
     # --------- helper for per-model input-species list -----------------------
     def load_input_species(combo_tag: str):
         """


### PR DESCRIPTION
## Summary
- detect non-2‑line FASTA files and raise helpful errors
- validate alignments in CLI entry points
- ensure saved-model predictions also check input files

## Testing
- `flake8 --select=F --exclude additional_code .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68659bf0870c8327b9148c083ee2e2d5