### PR TITLE
Fix Nuitka action for macOS build

### DIFF
--- a/.github/workflows/nuitka-build.yml
+++ b/.github/workflows/nuitka-build.yml
@@ -40,7 +40,6 @@ jobs:
           enable-plugins: |
             pyside6
             matplotlib
-          macos-create-app-bundle: "yes"
           nofollow-import-to: "*.tests"
       - name: Rename .app bundle
         run: mv build/main.app build/ESL-PSC.app


### PR DESCRIPTION
## Summary
- fix Nuitka build options so `--mode=app` is used instead of deprecated `--macos-create-app-bundle`

## Testing
- `flake8 --select=F --exclude additional_code .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6867f514ecbc8327ac20773f75f3ccc5