### PR TITLE
Fix standalone import error

### DIFF
--- a/esl_psc_cli/deletion_canceler.py
+++ b/esl_psc_cli/deletion_canceler.py
@@ -1,5 +1,5 @@
 import os, argparse, itertools, time
-from . import esl_psc_functions as ecf
+from esl_psc_cli import esl_psc_functions as ecf
 from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord

--- a/esl_psc_cli/esl_integrator.py
+++ b/esl_psc_cli/esl_integrator.py
@@ -1,7 +1,7 @@
 # a unified script for running integrated ESL analyses
 
 import argparse, os, time
-from . import esl_psc_functions as ecf
+from esl_psc_cli import esl_psc_functions as ecf
 from collections import defaultdict
 
 

--- a/esl_psc_cli/esl_multimatrix.py
+++ b/esl_psc_cli/esl_multimatrix.py
@@ -2,9 +2,9 @@
 #  matrices of species
 
 import argparse, os, time, shutil, random, itertools
-from . import esl_integrator as esl_int
-from . import esl_psc_functions as ecf
-from . import deletion_canceler as dc
+from esl_psc_cli import esl_integrator as esl_int
+from esl_psc_cli import esl_psc_functions as ecf
+from esl_psc_cli import deletion_canceler as dc
 from Bio import SeqIO
 from Bio.Seq import Seq
 

--- a/esl_psc_cli/esl_psc_functions.py
+++ b/esl_psc_cli/esl_psc_functions.py
@@ -9,7 +9,7 @@ warnings.filterwarnings("ignore", category=UserWarning)
 from collections import defaultdict, Counter
 from Bio import SeqIO
 import numpy as np
-from . import sps_density
+from esl_psc_cli import sps_density
 import pandas as pd
 import matplotlib.pyplot as plt
 from itertools import combinations, chain


### PR DESCRIPTION
## Summary
- support direct execution by using absolute imports

## Testing
- `flake8 --select=F --exclude additional_code .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6869cff1ea68832796a214324feb4a11