### PR TITLE
Handle esl_main_dir argument

### DIFF
--- a/esl_psc_cli/esl_integrator.py
+++ b/esl_psc_cli/esl_integrator.py
@@ -23,6 +23,12 @@ def get_esl_args(parser = None):
     '''
     group.add_argument('--esl_inputs_outputs_dir', help = help_txt,
                            type = str)
+
+    help_txt = '''Root folder of the ESL-PSC installation. This directory
+    must contain the ``bin`` subfolder with the ESL helper binaries. This
+    is typically auto-detected, but packaged builds may need to override it.'''
+    group.add_argument('--esl_main_dir', help = help_txt, type = str,
+                       required = False)
     help_txt = '''The full path to the species phenotypes file which has the 
     species name then a comma and then a 1 or -1 for the phenotype class.
     Any species that is not in the phenotype file will not be included in the

--- a/esl_psc_cli/esl_psc_functions.py
+++ b/esl_psc_cli/esl_psc_functions.py
@@ -44,7 +44,8 @@ def parse_args_with_config(parser, raw_args=None):
 
     # Point esl_main_dir at the *project root* (one level above this package)
     this_dir = os.path.dirname(os.path.abspath(__file__))
-    args.esl_main_dir = os.path.abspath(os.path.join(this_dir, os.pardir))
+    if not getattr(args, "esl_main_dir", None):
+        args.esl_main_dir = os.path.abspath(os.path.join(this_dir, os.pardir))
 
     # Determine default output directory
     if not getattr(args, "output_dir", None):


### PR DESCRIPTION
## Summary
- allow users to override ESL install path with new `--esl_main_dir` CLI option
- respect supplied `esl_main_dir` in argument parser

## Testing
- `flake8 --select=F --exclude additional_code .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6869e4f5e6448327b57f05baa47fa1f9