### PR TITLE
Fix missing matplotlib backend for SVG output

### DIFF
--- a/esl_psc_cli/esl_psc_functions.py
+++ b/esl_psc_cli/esl_psc_functions.py
@@ -12,6 +12,8 @@ import numpy as np
 from esl_psc_cli import sps_density
 import pandas as pd
 import matplotlib.pyplot as plt
+# Ensure the SVG backend is available when compiled with tools like Nuitka
+from matplotlib.backends import backend_svg  # noqa: F401
 from itertools import combinations, chain
 from statistics import median
 

--- a/esl_psc_cli/sps_density.py
+++ b/esl_psc_cli/sps_density.py
@@ -1,5 +1,7 @@
 #Author: Louise Dupont (with some additions by John)
 import matplotlib.pyplot as plt
+# Explicitly import the SVG backend so tools like Nuitka bundle it correctly
+from matplotlib.backends import backend_svg  # noqa: F401
 import seaborn as sns
 import pandas as pd
 import numpy as np


### PR DESCRIPTION
## Summary
- ensure matplotlib's SVG backend is explicitly imported in plotting modules

## Testing
- `flake8 --select=F --exclude additional_code .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686aeab15ac08327abf03e7a03623522