### PR TITLE
Add longest sequence/random options for auto-select pairs

### DIFF
--- a/gui/ui/pages/input_page.py
+++ b/gui/ui/pages/input_page.py
@@ -273,6 +273,7 @@ class InputPage(BaseWizardPage):
             phenotypes=phenos,
             on_pheno_changed=self._update_phenotype_file,
             on_groups_saved=self._update_groups_file,
+            alignments_dir=getattr(self.config, 'alignments_dir', ''),
         )
         self._tree_window.show()
 


### PR DESCRIPTION
## Summary
- make the TreeViewer aware of the alignments directory
- allow users to pick default, longest sequence, or random choice for auto-select
- compute species sequence lengths when needed with a progress dialog

## Testing
- `flake8 --select=F --exclude additional_code .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686afe82e54c83278a6ef2d7f1d09879