### PR TITLE
Fix dark mode gridline visibility

### DIFF
--- a/gui/ui/widgets/site_viewer.py
+++ b/gui/ui/widgets/site_viewer.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 from collections import Counter
 from typing import Any, Dict, List
 
-from PySide6.QtCore import Qt
-from PySide6.QtGui import QColor, QBrush, QFont
+from PySide6.QtCore import Qt, QEvent
+from PySide6.QtGui import QColor, QBrush, QFont, QPalette
 from PySide6.QtWidgets import (
     QTableWidget, QTableWidgetItem, QWidget, QVBoxLayout, QHBoxLayout,
     QSplitter, QSlider, QComboBox, QLabel, QPushButton,
@@ -365,6 +365,8 @@ class SiteViewer(QWidget):
         main_layout.addLayout(bottom_hbox, stretch=0)
 
         self.setLayout(main_layout)
+        # Adjust gridline colors based on current palette
+        self._apply_gridline_style()
         # Provide a taller default window to better fit all tables
         self.resize(1200, 1000)
 
@@ -1079,3 +1081,26 @@ class SiteViewer(QWidget):
             if r_sid == sid:
                 return seq
         return None
+
+    # ------------------------------------------------------------------
+    def _apply_gridline_style(self) -> None:
+        """Set table gridline colors to match the current color scheme."""
+        pal = self.palette()
+        window_lum = pal.color(QPalette.ColorRole.Window).lightness()
+        text_lum = pal.color(QPalette.ColorRole.WindowText).lightness()
+        is_dark = window_lum < text_lum
+        grid_color = "white" if is_dark else "black"
+        style = f"gridline-color: {grid_color};"
+        for tbl in [
+            self.top_left_table,
+            self.top_right_table,
+            self.bottom_left_table,
+            self.bottom_right_table,
+        ]:
+            tbl.setStyleSheet(style)
+
+    # ------------------------------------------------------------------
+    def changeEvent(self, event):  # noqa: N802 (Qt override)
+        if event.type() == QEvent.Type.PaletteChange:
+            self._apply_gridline_style()
+        super().changeEvent(event)


### PR DESCRIPTION
## Summary
- import `QPalette` and `QEvent` in `SiteViewer`
- apply a light/dark gridline style based on the palette
- update the style whenever the system color scheme changes

## Testing
- `flake8 --select=F --exclude additional_code .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686b090ab01c832786305ada6be2b187