### PR TITLE
Handle missing preprocess automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,9 @@ Note that the word the word "gene" is used here to refer to the genomic componen
 
 ##### Options:
 * `--use_logspace`: *Recommended* Use a log space of points for lambda values instead of initial and final lambda values with a lambda step.
-* `--use_existing_preprocess`: Use existing preprocess folder and skip running the preprocess step.
+* `--use_existing_preprocess`: Attempt to reuse existing preprocess folders. If a
+  required folder is missing it will be generated automatically and a warning
+  will be printed.
 * `--use_default_gp`: Don't replace group penalties (automatically set to True if the group_penalty_type is "std").
 * `--output_dir`: Directory where all output will be stored. If not supplied, a folder named `<output_file_base_name>_<timestamp>` will be created one level above the ESL-PSC project directory. Intermediate folders like `preprocessed_data_and_models`, `gap-canceled_alignments` and `response_matrices` will be created inside this location as needed.
 * `--keep_raw_output`: Don't delete the raw model output files for each run. The raw models can be found in the `preprocessed_data_and_models` directory within the directory specified by `--output_dir`. You can also set a new directory by using the `--esl_inputs_outputs_dir` argument, but note that any files ending in `.txt` will be cleared from this directory before each ESL-PSC run.

--- a/esl_psc_cli/esl_multimatrix.py
+++ b/esl_psc_cli/esl_multimatrix.py
@@ -236,23 +236,45 @@ def run_multi_matrix_integration(args, list_of_species_combos,
         
         if not args.make_pair_randomized_null_models:
             # ***Do a Normal Multimatrix Integration***
-            # run preprocess if needed
-            if not args.use_existing_preprocess:
-                # if the folder is there already remove it first
-                ecf.clear_existing_folder(
-                    os.path.join(args.esl_inputs_outputs_dir,
-                                 preprocess_dir_name))
-                ecf.run_preprocess(args.esl_main_dir, response_path,
-                                   path_file_path, preprocess_dir_name,
-                                   args.esl_inputs_outputs_dir, use_is = True)
-                
-            # run esl integration
-            _, run_list = esl_int.esl_integration(args,
-                                                  combo,
-                                                  preprocess_dir_name,
-                                                  gap_canceled_alignments_path,
-                                                  gene_objects_dict,
-                                                  combo_name)
+            preprocess_dir = os.path.join(args.esl_inputs_outputs_dir,
+                                          preprocess_dir_name)
+            if args.use_existing_preprocess:
+                if not os.path.isdir(preprocess_dir):
+                    print(
+                        f"WARNING: could not find preprocess directory '{preprocess_dir}'. "
+                        "Running preprocess now."
+                    )
+                    ecf.run_preprocess(
+                        args.esl_main_dir,
+                        response_path,
+                        path_file_path,
+                        preprocess_dir_name,
+                        args.esl_inputs_outputs_dir,
+                        use_is=True,
+                    )
+                else:
+                    print(f"Using existing preprocess directory: {preprocess_dir}")
+            else:
+                ecf.clear_existing_folder(preprocess_dir)
+                ecf.run_preprocess(
+                    args.esl_main_dir,
+                    response_path,
+                    path_file_path,
+                    preprocess_dir_name,
+                    args.esl_inputs_outputs_dir,
+                    use_is=True,
+                )
+
+            print(f"--- Building models for combo {combo_num + 1} of"
+                  f" {total_combos} ({combo_name}) ---")
+
+            _, run_list = esl_int.esl_integration(
+                args,
+                combo,
+                preprocess_dir_name,
+                gap_canceled_alignments_path,
+                gene_objects_dict,
+                combo_name)
             # gene_objects_dict is an object and only a reference is passed to
             #   each run so same object persists and accumulates all the data
             master_run_list.extend(run_list)

--- a/gui/ui/pages/parameters_page.py
+++ b/gui/ui/pages/parameters_page.py
@@ -396,7 +396,8 @@ class ParametersPage(BaseWizardPage):
         # --- Use existing preprocess option
         self.use_existing_preprocess = QCheckBox("Use existing preprocess")
         self.use_existing_preprocess.setToolTip(
-            "Use existing preprocess folder(s) with same output basename from a previous run) and skip running the preprocess step."
+            "Try to reuse preprocess folder(s) from a previous run. If a folder "
+            "is missing it will be generated automatically."
         )
         self.use_existing_preprocess.stateChanged.connect(
             lambda s: setattr(self.config, 'use_existing_preprocess', s == 2)


### PR DESCRIPTION
## Summary
- fill in missing preprocess directories when using `--use_existing_preprocess`
- print which combo is starting the model building step
- update README and GUI tooltip about preprocess behaviour

## Testing
- `flake8 --select=F --exclude additional_code .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68879abeec4883278c126b3b7d01f460