### PR TITLE
Allow predictions without phenotype file

### DIFF
--- a/esl_psc_cli/esl_multimatrix.py
+++ b/esl_psc_cli/esl_multimatrix.py
@@ -39,6 +39,10 @@ def validate_specific_paths(args):
             continue
 
         # Check existence
+        if attr_name == 'canceled_alignments_dir' and not getattr(args, 'use_existing_alignments', False):
+            # This directory will be created during the run when not reusing alignments
+            continue
+
         if not os.path.exists(path_value):
             problem_paths.append(f"{attr_name} = '{path_value}'")
 

--- a/gui/ui/pages/input_page.py
+++ b/gui/ui/pages/input_page.py
@@ -187,9 +187,11 @@ class InputPage(BaseWizardPage):
         self.species_phenotypes = FileSelector(
             "Species Phenotypes File:", 'file',
             default_path=os.getcwd(),
-            description="Optional: comma-separated file with species phenotypes. "
-            "First column is species ID, second column is phenotype value (1 or -1).\n"
-            "This is *required* for species prediction analyses."
+            description=(
+                "Optional: comma-separated file with species phenotypes. "
+                "First column is species ID, second column is phenotype value (1 or -1).\n"
+                "If omitted, the predictions output will not include a true phenotype column."
+            ),
         )
         self.species_phenotypes.path_changed.connect(
             lambda p: setattr(self.config, 'species_phenotypes_file', p)

--- a/gui/ui/widgets/existing_output_viewer.py
+++ b/gui/ui/widgets/existing_output_viewer.py
@@ -7,7 +7,6 @@ employed by the Run page.
 """
 from __future__ import annotations
 
-import json
 import os
 from typing import Optional
 


### PR DESCRIPTION
## Summary
- enable species predictions without a phenotype file in the GUI
- keep SPS plots gated on phenotype availability
- update tooltips and keep phenotype name fields enabled
- fix validation of cancelled alignments path in CLI
- remove unused import

## Testing
- `flake8 --select=F --exclude additional_code .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688c2e4171d4832791ee65487e04b450