### PR TITLE
Shorten CLI smoke test

### DIFF
--- a/gui/ui/widgets/label_items.py
+++ b/gui/ui/widgets/label_items.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, Dict
+from typing import Dict
 
 from PySide6.QtWidgets import QGraphicsTextItem
 from PySide6.QtCore import Qt

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -12,6 +12,7 @@ def test_demo_run_smoke(tmp_path):
     species_groups_src = project_root / "photo_single_LC_matrix_species_groups.txt"
     species_groups_file = tmp_path / "smoke_groups.txt"
     species_pheno_file = project_root / "photo_species_phenotypes.txt"
+    limited_genes_file = tmp_path / "limited_genes.txt"
 
     assert alignments_dir.exists(), "Demo alignments directory not found!"
     assert species_groups_src.exists(), "Demo species groups file not found!"
@@ -20,6 +21,10 @@ def test_demo_run_smoke(tmp_path):
     with open(species_groups_src) as src, open(species_groups_file, "w") as dst:
         for _ in range(4):
             dst.write(src.readline())
+
+    # Use only the top four genes from a full run to keep the smoke test fast
+    top_four_genes = ["ndhA.fas", "matk.fas", "clpP.fas", "ndhD.fas"]
+    limited_genes_file.write_text("\n".join(top_four_genes))
 
     output_basename = "smoke_test_output"
     output_dir = tmp_path / "output"
@@ -31,6 +36,7 @@ def test_demo_run_smoke(tmp_path):
         "--alignments_dir", str(alignments_dir),
         "--species_groups_file", str(species_groups_file),
         "--species_pheno_path", str(species_pheno_file),
+        "--limited_genes_list", str(limited_genes_file),
         "--output_file_base_name", output_basename,
         "--output_dir", str(output_dir),
         "--use_logspace",


### PR DESCRIPTION
## Summary
- Limit CLI smoke test to top four genes for faster execution
- Remove unused Optional import in label_items widget

## Testing
- `flake8 --select=F --exclude additional_code .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b0f19e3a248327a4f85180ad4cc57e