### PR TITLE
Support continuous phenotypes in ESL-PSC

### DIFF
--- a/esl_psc_cli/esl_integrator.py
+++ b/esl_psc_cli/esl_integrator.py
@@ -138,6 +138,12 @@ def get_esl_args(parser = None):
     True if the group_penalty_type is "std"'''
     group.add_argument('--use_default_gp', help = help_txt,
                         action = 'store_true', default = False)
+    help_txt = '''interpret provided phenotype values as continuous and use
+    linear regression (sg_lasso_leastr). By default, even if a phenotype file
+    contains non-binary values they will be treated as 1/-1 unless this flag
+    is supplied.'''
+    group.add_argument('--use_continuous_phenotypes', help = help_txt,
+                        action = 'store_true', default = False)
     help_txt = '''don't delete the raw model output files for each run'''
     group.add_argument('--keep_raw_output', help = help_txt,
                         action = 'store_true', default = False)
@@ -160,6 +166,9 @@ def get_esl_args(parser = None):
     help_txt = '''make a kde plot showing sps density for each true
     phenotype.'''
     group2.add_argument('--make_sps_kde_plot', help = help_txt,
+                        action = 'store_true', default = False)
+    help_txt = '''make a 2D density plot of true phenotype vs SPS values. Requires continuous phenotypes.'''
+    group2.add_argument('--make_continuous_plot', help = help_txt,
                         action = 'store_true', default = False)
     
     
@@ -232,7 +241,8 @@ def esl_integration(args,
                     preprocessed_dir_name,
                     input_alignments_dir,
                     gene_objects_dict,
-                    label = ''):
+                    label = '',
+                    response_matrix_path=None):
     """runs ESL for given inputs across lambda parameters and group penalties
     and returns dictionaries of objects for runs and genes. gene_objects_dict is
     a dictionary of ESLGeneObject as values and gene names as keys. label is
@@ -248,8 +258,16 @@ def esl_integration(args,
     # prepare variables for this integrated set of runs
     
     # dictionary of input species phenotypes
-    input_pheno_dict = ecf.make_input_pheno_dict(input_species_list)
-    print('species being checked:\n', ", ".join(input_species_list))
+    if getattr(args, 'species_pheno_is_continuous', False):
+        if response_matrix_path is None:
+            # Fall back to args.response_matrix_path for single-run executions
+            response_matrix_path = getattr(args, 'response_matrix_path', None)
+        if response_matrix_path is None:
+            raise ValueError('Continuous phenotypes requested but no response matrix path provided.')
+        input_pheno_dict = ecf.get_response_dict(response_matrix_path)
+    else:
+        input_pheno_dict = ecf.make_input_pheno_dict(input_species_list)
+    print('species being checked:\n', ", ".join(input_pheno_dict.keys()))
 
     # create a list of esl_run objects for the whole integration
     esl_run_list = []
@@ -515,7 +533,8 @@ if __name__ == '__main__':
                                                     input_species_list,
                                                     args.preprocessed_dir_name,
                                                     args.input_alignments_dir,
-                                                    gene_objects_dict)
+                                                    gene_objects_dict,
+                                                    response_matrix_path=args.response_matrix_path)
     
     
     # Print a clear, multi-line summary so the GUI output isn't squished
@@ -559,4 +578,8 @@ if __name__ == '__main__':
                                       args.pheno_names,
                                       args.min_genes,
                                       plot_type)
+    elif getattr(args, 'make_continuous_plot', False):
+        ecf.continuous_pred_plot(preds_output_path,
+                                 args.output_file_base_name,
+                                 args.min_genes)
 

--- a/esl_psc_cli/esl_multimatrix.py
+++ b/esl_psc_cli/esl_multimatrix.py
@@ -348,7 +348,8 @@ def run_multi_matrix_integration(args, list_of_species_combos,
                 preprocess_dir_name,
                 gap_canceled_alignments_path,
                 gene_objects_dict,
-                combo_name)
+                combo_name,
+                response_matrix_path=response_path)
             # gene_objects_dict is an object and only a reference is passed to
             #   each run so same object persists and accumulates all the data
             master_run_list.extend(run_list)
@@ -382,7 +383,8 @@ def run_multi_matrix_integration(args, list_of_species_combos,
                                                   rand_aligns,
                                                   gene_objects_dict,
                                                   combo_name
-                                                      + '_' + str(run_num))
+                                                      + '_' + str(run_num),
+                                                  response_matrix_path=response_path)
                 master_run_list.extend(run_list)
                 if checkpointer:
                     checkpointer.save_checkpoint(
@@ -563,12 +565,23 @@ def main(raw_args=None):
     #   The index of the file name in the list can be the combo code to
     #   link to the correct preprocess folder and gap-canceled alignments folder
 
+    pheno_dict = None
     if args.response_dir: # this means there is a directory of response matrices
         # sort them to get deterministic ordering
         response_file_list = sorted(os.listdir(args.response_dir))
         response_file_list = [os.path.join(args.response_dir, file) for
                               file in response_file_list] # full paths
         response_dir = args.response_dir # for use later
+        if any(ecf.response_matrix_is_continuous(f) for f in response_file_list):
+            args.species_pheno_is_continuous = True
+            print("Detected continuous phenotype values: running ESL-PSC with continuous response variables.")
+            if getattr(args, 'make_sps_plot', False) or getattr(args, 'make_sps_kde_plot', False):
+                print("SPS plots are disabled for continuous phenotype files.")
+                args.make_sps_plot = False
+                args.make_sps_kde_plot = False
+            if getattr(args, 'make_continuous_plot', False) and not getattr(args, 'species_pheno_path', None):
+                print("Continuous phenotype plots require a species phenotype file; skipping plot.")
+                args.make_continuous_plot = False
         # generate list_of_species_combos
         list_of_species_combos = []
         for response_file in response_file_list:
@@ -589,9 +602,13 @@ def main(raw_args=None):
                                     os.path.split(args.species_groups_file)[1]
                                     + '_response_matrices')
         response_dir = response_dir.replace('.txt', '') #delete group file ext
+        pheno_dict = None
+        if getattr(args, 'species_pheno_is_continuous', False):
+            pheno_dict = ecf.get_pheno_dict(args.species_pheno_path)
         if not args.make_null_models: # this will be done later if doing nulls
             response_file_list = ecf.make_response_files(response_dir,
-                                                         list_of_species_combos)
+                                                         list_of_species_combos,
+                                                         pheno_dict)
     else: 
         raise ValueError("must give either response_dir or species_groups_file")
     # we now have a response_file_list and a response_dir with the files in it
@@ -702,7 +719,8 @@ def main(raw_args=None):
         list_of_species_combos = ecf.make_null_combos(list_of_species_combos)
         # now fix the response directory
         response_file_list = ecf.make_response_files(response_dir,
-                                                     list_of_species_combos)
+                                                     list_of_species_combos,
+                                                     pheno_dict)
         
 
     # 2) Generate Gap-canceled Alignments
@@ -802,6 +820,10 @@ def main(raw_args=None):
                                   args.pheno_names,
                                   args.min_genes,
                                   plot_type)
+    elif getattr(args, 'make_continuous_plot', False):
+        ecf.continuous_pred_plot(preds_output_path,
+                                 args.output_file_base_name,
+                                 args.min_genes)
 
 if __name__ == '__main__':
     main()

--- a/esl_psc_cli/esl_psc_functions.py
+++ b/esl_psc_cli/esl_psc_functions.py
@@ -213,7 +213,11 @@ def parse_args_with_config(parser, raw_args=None):
 
 
     # Conditional error for missing species_pheno_path when plot generation is requested
-    plot_requested = getattr(args, 'make_sps_plot', False) or getattr(args, 'make_sps_kde_plot', False)
+    plot_requested = (
+        getattr(args, 'make_sps_plot', False)
+        or getattr(args, 'make_sps_kde_plot', False)
+        or getattr(args, 'make_continuous_plot', False)
+    )
     species_pheno_path_missing = not getattr(args, 'species_pheno_path', None)
 
     if plot_requested and species_pheno_path_missing:
@@ -223,7 +227,23 @@ def parse_args_with_config(parser, raw_args=None):
     if getattr(args, 'species_pheno_path', None):
         ph_type = detect_pheno_file_type(args.species_pheno_path)
         setattr(args, 'species_pheno_is_binary', ph_type == 'binary')
-        setattr(args, 'species_pheno_is_continuous', ph_type != 'binary')
+        use_cont = getattr(args, 'use_continuous_phenotypes', False) and ph_type != 'binary'
+        setattr(args, 'species_pheno_is_continuous', use_cont)
+
+        if ph_type != 'binary' and use_cont:
+            print("Detected continuous phenotype values: running ESL-PSC with continuous response variables.")
+            if getattr(args, 'make_sps_plot', False) or getattr(args, 'make_sps_kde_plot', False):
+                print("SPS plots are disabled for continuous phenotype files.")
+                args.make_sps_plot = False
+                args.make_sps_kde_plot = False
+        elif ph_type != 'binary' and not use_cont:
+            print("Continuous phenotype file detected but --use_continuous_phenotypes was not set; treating values as binary.")
+            if getattr(args, 'make_continuous_plot', False):
+                print("Continuous phenotype plots require --use_continuous_phenotypes; skipping plot.")
+                args.make_continuous_plot = False
+        elif ph_type == 'binary' and getattr(args, 'make_continuous_plot', False):
+            print("Phenotype file appears to be binary; continuous phenotype plot will be skipped.")
+            args.make_continuous_plot = False
     else:
         setattr(args, 'species_pheno_is_binary', False)
         setattr(args, 'species_pheno_is_continuous', False)
@@ -340,13 +360,42 @@ def get_species_to_check(response_matrix_path, check_order = False):
         if check_order:
             if line_index % 2 == 0:
                 # even indices are 0, 2, 4, i.e. 1st, 3rd, 5th
-                assert int(response_number) == 1 or int(response_number) == 0
+                assert float(response_number) == 1 or float(response_number) == 0
             else:
-                assert int(response_number) == -1 or int(response_number) == 0
+                assert float(response_number) == -1 or float(response_number) == 0
         #this shouldn't happen unless it's a pair
-        if int(response_number) != 0: 
+        if float(response_number) != 0:
             species_list.append(species_name)
     return species_list
+
+def response_matrix_is_continuous(response_matrix_path):
+    """Return True if *response_matrix_path* contains any response values other
+    than -1, 0, or 1."""
+    for line in file_lines_to_list(response_matrix_path):
+        parts = line.split('\t')
+        if len(parts) < 2:
+            continue
+        try:
+            value = float(parts[1])
+        except ValueError:
+            continue
+        if value not in (-1.0, 0.0, 1.0):
+            return True
+    return False
+
+def get_response_dict(response_matrix_path):
+    """Return a dict mapping species to numeric phenotype values from a
+    response matrix file."""
+    resp = {}
+    for line in file_lines_to_list(response_matrix_path):
+        parts = line.split('\t')
+        if len(parts) < 2:
+            continue
+        try:
+            resp[parts[0]] = float(parts[1])
+        except ValueError:
+            continue
+    return resp
 
 def make_taxa_list(alignments_dir_path):
     """Return a sorted list of all species IDs found in FASTA files."""
@@ -557,21 +606,30 @@ def clear_existing_folder(directory_path):
         raise Exception("trying to check if this directory exists "
                         + directory_path + " but this is not a directory")
 
-def make_response_files(response_dir, list_of_species_combos):
+def make_response_files(response_dir, list_of_species_combos, pheno_dict=None):
     '''takes a directory path, either existing or not, and a list of species
-    combos in 1, -1, 1, -1 order and generates an ESL response file for each
-    combo. returns a list of response file paths
+    combos and generates an ESL response file for each combo. When ``pheno_dict``
+    is ``None`` the combos are assumed to be in ``+1, -1, +1, -1`` order and the
+    responses are assigned accordingly. If ``pheno_dict`` is provided, the
+    numeric phenotype value for each species is looked up instead of using the
+    default binary pattern. returns a list of response file paths
     '''
     response_file_list = []
     clear_existing_folder(response_dir)
     os.mkdir(response_dir)
     # combinations are given sequential codes: 0, 1, 2...
     #   the same codes will be used in gap-canceled alignments & preprocess
-    for index1, combo in enumerate(list_of_species_combos): 
+    for index1, combo in enumerate(list_of_species_combos):
         response_lines = []
         for index2, species in enumerate(combo):
-            # assumes species greoups are listed in "+1, -1, +1, -1" order
-            response = 1 if index2 % 2 == 0 else -1
+            if pheno_dict is not None:
+                if species not in pheno_dict:
+                    raise ValueError(
+                        f"Species '{species}' missing from phenotype file")
+                response = pheno_dict[species]
+            else:
+                # assumes species groups are listed in "+1, -1, +1, -1" order
+                response = 1 if index2 % 2 == 0 else -1
             response_lines.append(species + '\t' + str(response))
         # response file names are combo_1.txt, combo_2.txt etc.
         file_path = (os.path.join(response_dir,
@@ -749,7 +807,39 @@ def rmse_range_pred_plots(pred_csv_path, title, pheno_names = None,
     report_elapsed_time(start_time)
     print("\npredictions density plot figure saved at: " + fig_path)
 
-    
+
+def continuous_pred_plot(pred_csv_path, title, min_genes=0):
+    """Generate a 2D density plot of true phenotype vs SPS."""
+    start_time = time.time()
+    print("making continuous phenotype plot...")
+
+    if threading.current_thread().name != "MainThread":
+        import matplotlib
+        matplotlib.use("Agg", force=True)
+
+    df = pd.read_csv(pred_csv_path, dtype={'species': str,
+                                           'SPS': float,
+                                           'num_genes': float,
+                                           'true_phenotype': float})
+    df = df[['species', 'SPS', 'num_genes', 'true_phenotype']]
+
+    fig_path = os.path.join(os.path.split(pred_csv_path)[0],
+                            title + '_continuous_plot.svg')
+
+    fig, ax = plt.subplots(figsize=(6, 5))
+    sps_density.create_continuous_plot(df=df, axes=ax,
+                                       title=title,
+                                       min_genes=min_genes)
+    fig.savefig(fig_path)
+
+    if sys.stdout.isatty():
+        plt.show()
+    else:
+        plt.close(fig)
+
+    report_elapsed_time(start_time)
+    print("\ncontinuous phenotype plot saved at: " + fig_path)
+
 
 class ESLRunFamily():
     '''a class to contain a family of runs with the same inputs.
@@ -938,11 +1028,17 @@ class ESLRun():
                 with open(slep_opts_path, "w") as sf:
                     sf.write(f"maxIter\t{maxiter}\n")
 
-            # Build command list for ESL logistic lasso.
-            # Use an argument list (shell=False) so paths that contain spaces are
-            # passed intact to the executable.
+            # Build command list for ESL lasso, selecting logistic or linear
+            # regression depending on whether the phenotype file is binary or
+            # continuous.  Use an argument list (shell=False) so paths that
+            # contain spaces are passed intact to the executable.
+            lasso_binary = (
+                "sg_lasso_leastr"
+                if getattr(self.run_family.args, "species_pheno_is_continuous", False)
+                else "sg_lasso"
+            )
             esl_command_list = [
-                get_binary_path(self.run_family.args.esl_main_dir, "sg_lasso"),
+                get_binary_path(self.run_family.args.esl_main_dir, lasso_binary),
                 "-f",
                 os.path.join(preprocessed_dir_name, f"feature_{preprocessed_dir_name}.txt"),
                 "-z",

--- a/esl_psc_cli/sps_density.py
+++ b/esl_psc_cli/sps_density.py
@@ -172,6 +172,50 @@ def create_sps_plot_violin(csv_file_path=None,
         fig.savefig(fig_path)
 
 
+def create_continuous_plot(csv_file_path=None,
+                          df=None,
+                          fig_path='plot.png',
+                          title='Phenotype vs SPS',
+                          axes=None,
+                          min_genes=0):
+    """Create a 2D density plot of true phenotype vs SPS.
+
+    Args:
+        csv_file_path: Optional path to the predictions CSV file.
+        df: Optional dataframe containing predictions. If provided it will
+            be copied to avoid mutation.
+        fig_path: Where to save the resulting figure (format inferred from
+            extension).
+        title: Plot title.
+        axes: Optional matplotlib axes to draw on.
+        min_genes: Minimum number of genes a model must have to be included.
+    """
+    if df is None:
+        df = pd.read_csv(csv_file_path)
+    else:
+        df = df.copy()
+
+    df = df[df['num_genes'] > min_genes]
+
+    if axes is None:
+        fig, axes = plt.subplots(nrows=1, ncols=1, figsize=(6, 5))
+    else:
+        fig = axes.get_figure()
+
+    sns.kdeplot(data=df, x='true_phenotype', y='SPS', fill=True,
+                cmap='viridis', thresh=0, levels=100, ax=axes)
+
+    axes.set_xlabel('True phenotype')
+    axes.set_ylabel('SPS')
+    axes.set_title(title, wrap=True)
+    axes.grid(color='white', linestyle='-', linewidth=0.5)
+    axes.set_facecolor('#ececec')
+    sns.despine(left=True, bottom=True)
+
+    if fig_path and axes is None:
+        fig.savefig(fig_path)
+
+
 # calculates percent accuracy directly from csv file- no longer use
 def calc_percent_accuracy_from_csv(csv_file_path):
     csv_file = open(csv_file_path, 'r')

--- a/gui/core/config.py
+++ b/gui/core/config.py
@@ -14,6 +14,13 @@ class ESLConfig:
     # Phenotype type detection (set by GUI when a phenotype file is chosen)
     species_pheno_is_binary: bool = False
     species_pheno_is_continuous: bool = False
+    # Whether ESL-PSC should treat phenotypes as continuous and use
+    # sg_lasso_leastr. Set via Parameters page or automatically when a
+    # response-matrix directory with continuous values is supplied.
+    use_continuous_phenotypes: bool = False
+    # Track if the provided response matrices already contain continuous values.
+    # When True, the GUI checkbox is locked in the "on" state.
+    response_matrices_are_continuous: bool = False
     prediction_alignments_dir: str = ""
     limited_genes_file: str = ""
     response_dir: str = ""
@@ -67,6 +74,7 @@ class ESLConfig:
     no_sps_plot: bool = True
     make_sps_plot: bool = False
     make_sps_kde_plot: bool = False
+    make_continuous_plot: bool = False
 
     # ─── Multi-matrix / null models ─────────────────────────────────────────────
     top_rank_frac: float = 0.01
@@ -101,6 +109,8 @@ class ESLConfig:
             a += ["--limited_genes_list", self.limited_genes_file]
         if self.response_dir:
             a += ["--response_dir", self.response_dir]
+        if getattr(self, 'use_continuous_phenotypes', False):
+            a.append("--use_continuous_phenotypes")
             
         # Output configuration
         a += ["--output_file_base_name", self.output_file_base_name]
@@ -160,10 +170,13 @@ class ESLConfig:
         no_pred = getattr(self, 'no_pred_output', False)
         a += self._flag(no_pred, "--no_pred_output")
         
-        # Only include plot flags if we're generating prediction output AND phenotypes are binary
-        if not no_pred and getattr(self, 'species_pheno_is_binary', False):
-            a += self._flag(getattr(self, 'make_sps_plot', False), "--make_sps_plot")
-            a += self._flag(getattr(self, 'make_sps_kde_plot', False), "--make_sps_kde_plot")
+        # Only include plot flags if we're generating prediction output
+        if not no_pred:
+            if getattr(self, 'species_pheno_is_binary', False):
+                a += self._flag(getattr(self, 'make_sps_plot', False), "--make_sps_plot")
+                a += self._flag(getattr(self, 'make_sps_kde_plot', False), "--make_sps_kde_plot")
+            if getattr(self, 'use_continuous_phenotypes', False) or getattr(self, 'response_matrices_are_continuous', False):
+                a += self._flag(getattr(self, 'make_continuous_plot', False), "--make_continuous_plot")
         
         # Null model options
         if hasattr(self, 'make_null_models') and self.make_null_models:

--- a/gui/ui/pages/command_page.py
+++ b/gui/ui/pages/command_page.py
@@ -182,6 +182,8 @@ class CommandPage(BaseWizardPage):
             self.add_summary_item(layout, "Limited Genes:", self.config.limited_genes_file)
         if hasattr(self.config, 'response_dir') and self.config.response_dir:
             self.add_summary_item(layout, "Response Directory:", self.config.response_dir)
+        if getattr(self.config, 'use_continuous_phenotypes', False):
+            self.add_summary_item(layout, "Response Type:", "Continuous phenotypes")
         
         # Add a header for analysis parameters
         params_header = QLabel("Analysis Parameters")
@@ -275,8 +277,11 @@ class CommandPage(BaseWizardPage):
         # SPS plot settings – show SPS, KDE, or both depending on selections
         make_sps_plot = getattr(self.config, 'make_sps_plot', False)
         make_kde_plot = getattr(self.config, 'make_sps_kde_plot', False)
+        make_cont_plot = getattr(self.config, 'make_continuous_plot', False)
 
-        if make_sps_plot and make_kde_plot:
+        if make_cont_plot:
+            output_settings.append("Generate phenotype density plot")
+        elif make_sps_plot and make_kde_plot:
             output_settings.append("Generate SPS and KDE plots")
         elif make_sps_plot:
             output_settings.append("Generate SPS plots")

--- a/gui/ui/pages/input_page.py
+++ b/gui/ui/pages/input_page.py
@@ -10,6 +10,8 @@ from PySide6.QtCore import Qt  # Needed for alignment
 from gui.ui.widgets.existing_output_viewer import select_and_show_existing_output
 import os
 
+from esl_psc_cli import esl_psc_functions as ecf
+
 from gui.ui.widgets.file_selectors import FileSelector
 from gui.ui.widgets.tree_viewer import TreeViewer
 from Bio import Phylo
@@ -149,9 +151,7 @@ class InputPage(BaseWizardPage):
                 "Typically used for advanced analyses or when reusing previously computed matrices."
             )
         )
-        self.response_dir.path_changed.connect(
-            lambda p: setattr(self.config, 'response_dir', p)
-        )
+        self.response_dir.path_changed.connect(self._on_response_dir_changed)
         self.response_dir.setVisible(False)  # Start hidden
         self.input_files_layout.addWidget(self.response_dir)
         
@@ -173,6 +173,8 @@ class InputPage(BaseWizardPage):
             else:
                 # Clear response dir path when switching to species groups
                 self.config.response_dir = ""
+                self.config.response_matrices_are_continuous = False
+                self.config.use_continuous_phenotypes = False
         
         self.use_species_groups.toggled.connect(update_input_visibility)
         self.use_response_dir.toggled.connect(update_input_visibility)
@@ -346,6 +348,31 @@ class InputPage(BaseWizardPage):
         except Exception:
             # On error, leave flags False so downstream treats as absent for plots
             pass
+
+    def _on_response_dir_changed(self, path: str) -> None:
+        """Set response directory and detect continuous response matrices."""
+        setattr(self.config, 'response_dir', path)
+        self.config.response_matrices_are_continuous = False
+        if not path or not os.path.isdir(path):
+            self.config.use_continuous_phenotypes = False
+            return
+        try:
+            for fname in os.listdir(path):
+                if not fname.endswith('.txt'):
+                    continue
+                full = os.path.join(path, fname)
+                if ecf.response_matrix_is_continuous(full):
+                    self.config.response_matrices_are_continuous = True
+                    self.config.use_continuous_phenotypes = True
+                    self.config.species_pheno_is_continuous = True
+                    break
+            else:
+                self.config.use_continuous_phenotypes = False
+                self.config.species_pheno_is_continuous = False
+        except Exception:
+            # Ignore detection errors; treat as binary
+            self.config.use_continuous_phenotypes = False
+            self.config.species_pheno_is_continuous = False
 
     def _update_phenotype_file(self, path: str) -> None:
         """Update the phenotype file selector and config."""

--- a/gui/ui/pages/parameters_page.py
+++ b/gui/ui/pages/parameters_page.py
@@ -231,9 +231,24 @@ class ParametersPage(BaseWizardPage):
         
         # Add standard spacing after phenotype names
         output_layout.addSpacing(8)
-        
+
         # Add vertical spacer for better separation before output directory
         output_layout.addSpacing(5)  # Reduced spacing before output directory
+
+        # Option to use continuous response values
+        def _on_continuous_toggled(checked):
+            self.config.use_continuous_phenotypes = checked
+            if hasattr(self, '_update_sps_plot_state'):
+                self._update_sps_plot_state()
+            self.update_output_options_state()
+
+        self.use_continuous_chk = QCheckBox("Use continuous phenotype values")
+        self.use_continuous_chk.toggled.connect(_on_continuous_toggled)
+        self.use_continuous_chk.setToolTip(
+            "Run ESL-PSC with continuous response variables using sg_lasso_leastr."
+        )
+        self.use_continuous_chk.setVisible(False)
+        output_layout.addWidget(self.use_continuous_chk)
         
         # SPS plot options (always visible but may be disabled)
         self.sps_plot_group = QGroupBox("Species Prediction Score (SPS) Plots")
@@ -279,30 +294,68 @@ class ParametersPage(BaseWizardPage):
         self.config.no_sps_plot = True
         self.config.make_sps_plot = False
         self.config.make_sps_kde_plot = False
-        
+        self.config.make_continuous_plot = False
+
         self.sps_plot_group.setLayout(sps_plot_layout)
         output_layout.addWidget(self.sps_plot_group)
+
+        self.continuous_plot_chk = QCheckBox("Generate phenotype density plot")
+        self.continuous_plot_chk.setToolTip(
+            "Create a 2D density plot with true phenotype on the X-axis and SPS on the Y-axis."
+        )
+        self.continuous_plot_chk.toggled.connect(
+            lambda checked: setattr(self.config, 'make_continuous_plot', checked)
+        )
+        self.continuous_plot_chk.setVisible(False)
+        output_layout.addWidget(self.continuous_plot_chk)
         
         # Connect output type changes to enable/disable SPS plot options
         def update_sps_plot_state():
-            enable_sps = not self.genes_only_btn.isChecked() and self.has_species_pheno
-            self.sps_plot_group.setEnabled(enable_sps)
+            cont_active = (
+                getattr(self.config, 'use_continuous_phenotypes', False)
+                or getattr(self.config, 'response_matrices_are_continuous', False)
+            )
+            show_sps = (
+                not self.genes_only_btn.isChecked()
+                and self.has_species_pheno
+                and not cont_active
+            )
+            self.sps_plot_group.setVisible(show_sps)
+            self.sps_plot_group.setEnabled(show_sps)
             self.sps_plot_group.setStyleSheet(
                 "QGroupBox:disabled { color: gray; }"
                 "QCheckBox:disabled { color: gray; }"
             )
 
-            if self.has_species_pheno:
+            cont_visible = (
+                not self.genes_only_btn.isChecked()
+                and self.has_species_pheno
+                and cont_active
+            )
+            self.continuous_plot_chk.setVisible(cont_visible)
+            if not cont_visible:
+                self.continuous_plot_chk.setChecked(False)
+
+            if not self.has_species_pheno:
+                warn = "<font color='red'>Requires a binary species phenotype file (-1/1) to generate SPS plots.</font>"
+                self.make_sps_plot.setToolTip(warn)
+                self.make_sps_kde_plot.setToolTip(warn)
+                self.continuous_plot_chk.setToolTip("Requires a species phenotype file to generate plots.")
+            elif cont_active:
+                warn = "<font color='red'>SPS plots are disabled for continuous phenotypes.</font>"
+                self.make_sps_plot.setToolTip(warn)
+                self.make_sps_kde_plot.setToolTip(warn)
+                self.continuous_plot_chk.setToolTip(
+                    "Create a 2D density plot with true phenotype on the X-axis and SPS on the Y-axis."
+                )
+            else:
                 self.make_sps_plot.setToolTip(
                     "Create violin plots showing SPS density for each true phenotype."
                 )
                 self.make_sps_kde_plot.setToolTip(
                     "Create Kernel Density Estimate (KDE) plots showing SPS density for each true phenotype."
                 )
-            else:
-                warn = "<font color='red'>Requires a binary species phenotype file (-1/1) to generate SPS plots.</font>"
-                self.make_sps_plot.setToolTip(warn)
-                self.make_sps_kde_plot.setToolTip(warn)
+
         
         self.genes_only_btn.toggled.connect(update_sps_plot_state)
         self.preds_only_btn.toggled.connect(update_sps_plot_state)
@@ -815,7 +868,9 @@ class ParametersPage(BaseWizardPage):
         # Do NOT reset input file paths or other pages' settings
         skip_fields = {
             "alignments_dir", "species_groups_file", "species_phenotypes_file",
-            "prediction_alignments_dir", "limited_genes_file", "response_dir"
+            "prediction_alignments_dir", "limited_genes_file", "response_dir",
+            "species_pheno_is_binary", "species_pheno_is_continuous",
+            "response_matrices_are_continuous"
         }
         for f in fields(ESLConfig):
             if f.name in skip_fields:
@@ -931,6 +986,8 @@ class ParametersPage(BaseWizardPage):
             self.make_sps_plot.setChecked(cfg.make_sps_plot)
         if hasattr(self, 'make_sps_kde_plot'):
             self.make_sps_kde_plot.setChecked(cfg.make_sps_kde_plot)
+        if hasattr(self, 'continuous_plot_chk'):
+            self.continuous_plot_chk.setChecked(getattr(cfg, 'make_continuous_plot', False))
         # Deletion canceler
         self.nix_full_deletions.setChecked(cfg.nix_full_deletions)
         self.cancel_only_partner.setChecked(cfg.cancel_only_partner)
@@ -938,6 +995,11 @@ class ParametersPage(BaseWizardPage):
         self.use_existing_alignments.setChecked(getattr(cfg, 'use_existing_alignments', False))
         self.canceled_alignments_selector.set_path(getattr(cfg, 'canceled_alignments_dir', ''))
         self.canceled_alignments_selector.setVisible(getattr(cfg, 'use_existing_alignments', False))
+
+        if hasattr(self, 'use_continuous_chk'):
+            self.use_continuous_chk.setChecked(cfg.use_continuous_phenotypes)
+
+        self.update_output_options_state()
         # Update Output Files radios from config (block signals so we don’t write back immediately)
         for btn in (self.genes_only_btn, self.preds_only_btn, self.both_outputs_btn):
             btn.blockSignals(True)
@@ -1033,12 +1095,21 @@ class ParametersPage(BaseWizardPage):
             wiz = self.wizard()
             if wiz and hasattr(wiz, 'input_page'):
                 path = wiz.input_page.species_phenotypes.get_path()
-                self.has_species_pheno = bool(path) and bool(getattr(self.config, 'species_pheno_is_binary', False))
+                self.has_species_pheno = bool(path) and (
+                    getattr(self.config, 'species_pheno_is_binary', False)
+                    or getattr(self.config, 'species_pheno_is_continuous', False)
+                )
             else:
                 # Fallback to the value already stored in the config
-                self.has_species_pheno = bool(getattr(self.config, 'species_phenotypes_file', '')) and bool(getattr(self.config, 'species_pheno_is_binary', False))
+                self.has_species_pheno = bool(getattr(self.config, 'species_phenotypes_file', '')) and (
+                    getattr(self.config, 'species_pheno_is_binary', False)
+                    or getattr(self.config, 'species_pheno_is_continuous', False)
+                )
         except Exception:
-            self.has_species_pheno = bool(getattr(self.config, 'species_phenotypes_file', '')) and bool(getattr(self.config, 'species_pheno_is_binary', False))
+            self.has_species_pheno = bool(getattr(self.config, 'species_phenotypes_file', '')) and (
+                getattr(self.config, 'species_pheno_is_binary', False)
+                or getattr(self.config, 'species_pheno_is_continuous', False)
+            )
 
         if not getattr(self, 'widgets_initialized', False):
             return
@@ -1068,6 +1139,32 @@ class ParametersPage(BaseWizardPage):
                 self.both_outputs_btn.setToolTip(
                     "Generate both gene ranks and species predictions outputs. The predictions file will not include a true phenotype column."
                 )
+
+            # Continuous phenotype handling
+            has_cont = (
+                getattr(self.config, 'species_pheno_is_continuous', False)
+                or getattr(self.config, 'response_matrices_are_continuous', False)
+            )
+            self.use_continuous_chk.setVisible(has_cont)
+            if getattr(self.config, 'response_matrices_are_continuous', False):
+                self.use_continuous_chk.setChecked(True)
+                self.use_continuous_chk.setEnabled(False)
+                self.use_continuous_chk.setToolTip(
+                    "Continuous response matrices detected; continuous phenotypes required."
+                )
+                self.config.use_continuous_phenotypes = True
+            elif has_cont:
+                self.use_continuous_chk.setEnabled(True)
+                self.use_continuous_chk.setChecked(self.config.use_continuous_phenotypes)
+                self.use_continuous_chk.setToolTip(
+                    "Run ESL-PSC with continuous response variables using sg_lasso_leastr."
+                )
+            else:
+                self.use_continuous_chk.setChecked(False)
+                self.config.use_continuous_phenotypes = False
+
+            if hasattr(self, '_update_sps_plot_state'):
+                self._update_sps_plot_state()
 
         except RuntimeError:
             # Widgets have been deleted, ignore

--- a/gui/ui/pages/run_page.py
+++ b/gui/ui/pages/run_page.py
@@ -12,7 +12,7 @@ from PySide6.QtWidgets import (
 from gui.core.worker import ESLWorker
 from .base_page import BaseWizardPage
 from gui.ui.widgets.results_display import (
-    SpsPlotDialog, GeneRanksDialog
+    SpsPlotDialog, GeneRanksDialog, ContinuousPlotDialog
 )
 
 class RunPage(BaseWizardPage):
@@ -64,11 +64,15 @@ class RunPage(BaseWizardPage):
         self.sps_btn = QPushButton("Show SPS Plot")
         self.sps_btn.hide()
         self.sps_btn.clicked.connect(self.show_sps_plot)
+        self.cont_btn = QPushButton("Show Phenotype Plot")
+        self.cont_btn.hide()
+        self.cont_btn.clicked.connect(self.show_cont_plot)
         self.gene_btn = QPushButton("Show Top Gene Ranks")
         self.gene_btn.hide()
         self.gene_btn.clicked.connect(self.show_gene_ranks)
         self.results_layout.addStretch()
         self.results_layout.addWidget(self.sps_btn)
+        self.results_layout.addWidget(self.cont_btn)
         self.results_layout.addWidget(self.gene_btn)
         container_layout.addLayout(self.results_layout)
 
@@ -249,8 +253,10 @@ class RunPage(BaseWizardPage):
             self.cmd_display.appendPlainText(f"$ python -m esl_multimatrix.py {self.config.get_command_string()}")
             self.step_status_label.setText("Starting analysis (may take 10 seconds)...")
             self.sps_btn.hide()
+            self.cont_btn.hide()
             self.gene_btn.hide()
             self.sps_plot_path = None
+            self.cont_plot_path = None
             self.gene_ranks_path = None
             self.selected_sites_path = None
 
@@ -306,6 +312,13 @@ class RunPage(BaseWizardPage):
         else:
             QMessageBox.warning(self, "File Not Found", "The SPS plot file could not be found.")
 
+    def show_cont_plot(self):
+        """Slot to show the continuous phenotype plot if available."""
+        if self.cont_plot_path and os.path.exists(self.cont_plot_path):
+            ContinuousPlotDialog.show_dialog(self.cont_plot_path, parent=self)
+        else:
+            QMessageBox.warning(self, "File Not Found", "The phenotype plot file could not be found.")
+
     def show_gene_ranks(self):
         """Slot to show the gene ranks table if available."""
         if self.gene_ranks_path and os.path.exists(self.gene_ranks_path):
@@ -350,6 +363,14 @@ class RunPage(BaseWizardPage):
                 if os.path.exists(path):
                     self.sps_plot_path = path
                     self.sps_btn.show()
+
+            self.cont_plot_path = None
+            if getattr(self.config, "make_continuous_plot", False) and not getattr(self.config, "no_pred_output", False):
+                cont_name = f"{base}_continuous_plot.svg"
+                path = os.path.abspath(os.path.join(out_dir, cont_name))
+                if os.path.exists(path):
+                    self.cont_plot_path = path
+                    self.cont_btn.show()
 
             ranks_path = os.path.abspath(os.path.join(out_dir, f"{base}_gene_ranks.csv"))
             # Only show the button if gene output was requested in this run

--- a/gui/ui/widgets/existing_output_viewer.py
+++ b/gui/ui/widgets/existing_output_viewer.py
@@ -22,7 +22,7 @@ from PySide6.QtWidgets import (
 )
 
 from gui.core.config import ESLConfig
-from gui.ui.widgets.results_display import SpsPlotDialog, GeneRanksDialog
+from gui.ui.widgets.results_display import SpsPlotDialog, GeneRanksDialog, ContinuousPlotDialog
 
 __all__ = [
     "select_and_show_existing_output",
@@ -73,6 +73,7 @@ class _ExistingOutputDialog(QDialog):
         btn_layout.addStretch()
 
         self._sps_path: Optional[str] = self._find_sps_plot()
+        self._cont_path: Optional[str] = self._find_cont_plot()
         self._gene_ranks_path: Optional[str] = self._find_gene_ranks()
         self._sites_path: Optional[str] = self._find_selected_sites()
 
@@ -88,6 +89,19 @@ class _ExistingOutputDialog(QDialog):
             self._sps_btn.setGraphicsEffect(eff)
         self._sps_btn.clicked.connect(self._show_sps)
         btn_layout.addWidget(self._sps_btn)
+
+        self._cont_btn = QPushButton("Show Phenotype Plot")
+        if self._cont_path:
+            self._cont_btn.setToolTip("Open the phenotype density plot from this run")
+        else:
+            self._cont_btn.setEnabled(False)
+            self._cont_btn.setToolTip("No phenotype plot found in this output folder")
+            from PySide6.QtWidgets import QGraphicsOpacityEffect
+            eff = QGraphicsOpacityEffect(self._cont_btn)
+            eff.setOpacity(0.4)
+            self._cont_btn.setGraphicsEffect(eff)
+        self._cont_btn.clicked.connect(self._show_cont)
+        btn_layout.addWidget(self._cont_btn)
 
         self._gene_btn = QPushButton("Show Gene Ranks")
         if self._gene_ranks_path:
@@ -116,6 +130,13 @@ class _ExistingOutputDialog(QDialog):
         cand = os.path.join(self._output_dir, f"{base}_pred_sps_plot.svg")
         return cand if os.path.exists(cand) else None
 
+    def _find_cont_plot(self) -> Optional[str]:
+        base = self._cfg.output_file_base_name
+        if not base or getattr(self._cfg, "no_pred_output", False):
+            return None
+        cand = os.path.join(self._output_dir, f"{base}_continuous_plot.svg")
+        return cand if os.path.exists(cand) else None
+
     def _find_gene_ranks(self) -> Optional[str]:
         base = self._cfg.output_file_base_name
         if not base or getattr(self._cfg, "no_genes_output", False):
@@ -136,6 +157,12 @@ class _ExistingOutputDialog(QDialog):
             SpsPlotDialog.show_dialog(self._sps_path, parent=self)
         else:
             QMessageBox.information(self, "Unavailable", "No SPS plot found for this run.")
+
+    def _show_cont(self):  # pragma: no cover – UI slot
+        if self._cont_path:
+            ContinuousPlotDialog.show_dialog(self._cont_path, parent=self)
+        else:
+            QMessageBox.information(self, "Unavailable", "No phenotype plot found for this run.")
 
     def _show_gene_ranks(self):  # pragma: no cover – UI slot
         if self._gene_ranks_path:

--- a/gui/ui/widgets/results_display.py
+++ b/gui/ui/widgets/results_display.py
@@ -144,6 +144,25 @@ class SpsPlotDialog(QDialog):
         _open_dialogs.append(dialog)
 
 
+class ContinuousPlotDialog(QDialog):
+    """Dialog to display the continuous phenotype plot."""
+
+    def __init__(self, svg_path, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Phenotype vs SPS Plot")
+        layout = QVBoxLayout(self)
+        svg_widget = QSvgWidget(svg_path)
+        svg_widget.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        layout.addWidget(svg_widget)
+        self.resize(680, 600)
+
+    @staticmethod
+    def show_dialog(svg_path, parent=None):
+        dialog = ContinuousPlotDialog(svg_path, parent)
+        dialog.show()
+        _open_dialogs.append(dialog)
+
+
 class GeneRanksDialog(QDialog):
     """Dialog to display top gene ranks and optional selected sites."""
 

--- a/tests/test_cli_continuous.py
+++ b/tests/test_cli_continuous.py
@@ -1,0 +1,146 @@
+import subprocess
+import sys
+from pathlib import Path
+
+def test_continuous_pheno_disables_plots(tmp_path):
+    project_root = Path(__file__).parent.parent
+    alignments_dir = project_root / "photosynthesis_alignments"
+    species_groups_src = project_root / "photo_single_LC_matrix_species_groups.txt"
+    species_groups_file = tmp_path / "groups.txt"
+    species_pheno_src = project_root / "photo_species_phenotypes.txt"
+    continuous_pheno_file = tmp_path / "continuous_pheno.txt"
+    limited_genes_file = tmp_path / "limited_genes.txt"
+
+    assert alignments_dir.exists()
+    assert species_groups_src.exists()
+
+    # use first four species entries to keep run small
+    with open(species_groups_src) as src, open(species_groups_file, "w") as dst:
+        for _ in range(4):
+            dst.write(src.readline())
+
+    # top two genes for fast run
+    top_genes = ["ndhA.fas", "matk.fas"]
+    limited_genes_file.write_text("\n".join(top_genes))
+
+    # build a continuous phenotype file using values 1.0..n*1.0
+    cont_lines = []
+    expected_values = {}
+    with open(species_pheno_src) as src:
+        for idx, line in enumerate(src, 1):
+            line = line.strip()
+            if not line:
+                continue
+            species = line.split(",")[0]
+            value = float(idx)
+            cont_lines.append(f"{species},{value}\n")
+            expected_values[species] = value
+    continuous_pheno_file.write_text("".join(cont_lines))
+
+    output_basename = "continuous_test_output"
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    cmd = [
+        sys.executable,
+        "-m", "esl_multimatrix",
+        "--alignments_dir", str(alignments_dir),
+        "--species_groups_file", str(species_groups_file),
+        "--species_pheno_path", str(continuous_pheno_file),
+        "--limited_genes_list", str(limited_genes_file),
+        "--output_file_base_name", output_basename,
+        "--output_dir", str(output_dir),
+        "--use_continuous_phenotypes",
+        "--use_logspace",
+        "--num_log_points", "2",
+        "--make_sps_plot",
+        "--show_selected_sites",
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert "continuous response variables" in result.stdout
+
+    # SPS plots should be skipped even if requested
+    plot_file = output_dir / f"{output_basename}_pred_sps_plot.svg"
+    assert not plot_file.exists()
+
+    # Core output tables should still be produced
+    predictions = output_dir / f"{output_basename}_species_predictions.csv"
+    ranks = output_dir / f"{output_basename}_gene_ranks.csv"
+    sites = output_dir / f"{output_basename}_selected_sites.csv"
+    for f in (predictions, ranks, sites):
+        assert f.exists() and f.stat().st_size > 0
+
+    # Response matrix should contain the fabricated continuous values
+    resp_dir = output_dir / f"{species_groups_file.stem}_response_matrices"
+    resp_file = resp_dir / "combo_0.txt"
+    assert resp_file.exists()
+    contents = resp_file.read_text().strip().splitlines()
+    for line in contents:
+        species, value = line.split("\t")
+        assert float(value) == expected_values[species]
+
+    # Now ensure the continuous plot option works
+    output_dir2 = tmp_path / "out2"
+    output_dir2.mkdir()
+    base2 = "continuous_plot_output"
+    cmd2 = [
+        sys.executable,
+        "-m", "esl_multimatrix",
+        "--alignments_dir", str(alignments_dir),
+        "--species_groups_file", str(species_groups_file),
+        "--species_pheno_path", str(continuous_pheno_file),
+        "--limited_genes_list", str(limited_genes_file),
+        "--output_file_base_name", base2,
+        "--output_dir", str(output_dir2),
+        "--use_continuous_phenotypes",
+        "--use_logspace",
+        "--num_log_points", "2",
+        "--make_continuous_plot",
+    ]
+    result2 = subprocess.run(cmd2, capture_output=True, text=True)
+    assert result2.returncode == 0, result2.stderr
+    cont_plot = output_dir2 / f"{base2}_continuous_plot.svg"
+    assert cont_plot.exists()
+
+
+def test_response_dir_with_continuous_values(tmp_path):
+    project_root = Path(__file__).parent.parent
+    alignments_dir = project_root / "photosynthesis_alignments"
+    species_pheno_src = project_root / "photo_species_phenotypes.txt"
+    response_dir = tmp_path / "resp"
+    response_dir.mkdir()
+
+    species = []
+    with open(species_pheno_src) as src:
+        for line in src:
+            if len(species) >= 4:
+                break
+            species.append(line.split(",")[0])
+    with open(response_dir / "resp.txt", "w") as dst:
+        for idx, sp in enumerate(species, 1):
+            dst.write(f"{sp}\t{float(idx)}\n")
+
+    limited_genes_file = tmp_path / "limited_genes.txt"
+    limited_genes_file.write_text("ndhA.fas\nmatk.fas")
+
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    cmd = [
+        sys.executable,
+        "-m", "esl_multimatrix",
+        "--alignments_dir", str(alignments_dir),
+        "--response_dir", str(response_dir),
+        "--limited_genes_list", str(limited_genes_file),
+        "--output_file_base_name", "out",
+        "--output_dir", str(output_dir),
+        "--use_logspace",
+        "--num_log_points", "2",
+        "--no_pred_output",
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert "continuous response variables" in result.stdout

--- a/tests/test_gui_continuous.py
+++ b/tests/test_gui_continuous.py
@@ -1,0 +1,50 @@
+from PySide6.QtWidgets import QLineEdit
+
+from gui.core.config import ESLConfig
+from gui.ui.pages.parameters_page import ParametersPage
+from gui.ui.pages.command_page import CommandPage
+
+
+def test_checkbox_with_continuous_pheno(qt_app):
+    cfg = ESLConfig()
+    cfg.species_pheno_is_continuous = True
+    cfg.species_phenotypes_file = "dummy.csv"
+    params = ParametersPage(cfg)
+    params.update_output_options_state()
+    params.show()
+    assert params.use_continuous_chk.isVisible()
+    assert params.use_continuous_chk.isEnabled()
+    params.use_continuous_chk.setChecked(True)
+    assert cfg.use_continuous_phenotypes
+    assert params.continuous_plot_chk.isVisible()
+    params.continuous_plot_chk.setChecked(True)
+    assert cfg.make_continuous_plot
+    cmd_page = CommandPage(cfg)
+    cmd_page.on_enter()
+    cmd_page.show()
+    qt_app.processEvents()
+    assert "--use_continuous_phenotypes" in cmd_page.cmd_display.toPlainText()
+    assert "--make_continuous_plot" in cmd_page.cmd_display.toPlainText()
+    texts = [w.text() for w in cmd_page.summary_group.findChildren(QLineEdit)]
+    assert any("Continuous phenotypes" in t for t in texts)
+
+
+def test_checkbox_locked_for_response_dir(qt_app):
+    cfg = ESLConfig()
+    cfg.response_dir = "respdir"
+    cfg.response_matrices_are_continuous = True
+    cfg.use_continuous_phenotypes = True
+    params = ParametersPage(cfg)
+    params.update_output_options_state()
+    params.show()
+    assert params.use_continuous_chk.isVisible()
+    assert not params.use_continuous_chk.isEnabled()
+    assert params.use_continuous_chk.isChecked()
+    assert not params.continuous_plot_chk.isVisible()
+    cmd_page = CommandPage(cfg)
+    cmd_page.on_enter()
+    cmd_page.show()
+    qt_app.processEvents()
+    assert "--use_continuous_phenotypes" in cmd_page.cmd_display.toPlainText()
+    texts = [w.text() for w in cmd_page.summary_group.findChildren(QLineEdit)]
+    assert any("Continuous phenotypes" in t for t in texts)


### PR DESCRIPTION
## Summary
- gate continuous-response runs behind a new `--use_continuous_phenotypes` flag
- auto-detect continuous response matrices and route through `sg_lasso_leastr`
- parse response matrices with numeric values and plumb them into RMSE calculations
- expose a GUI checkbox for continuous phenotypes that locks on when response matrices already contain continuous values
- add 2D phenotype vs SPS density plots for continuous runs

## Testing
- `flake8 --select=F --exclude additional_code .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b32a227750832784a178e0f49248a6