### PR TITLE
Fix continuous phenotype display in site viewer

### DIFF
--- a/gui/ui/pages/parameters_page.py
+++ b/gui/ui/pages/parameters_page.py
@@ -295,6 +295,22 @@ class ParametersPage(BaseWizardPage):
         )
         self.continuous_plot_chk.setVisible(False)
         output_layout.addWidget(self.continuous_plot_chk)
+
+        # Toggle for using continuous phenotypes (mirrors InputPage control)
+        self.use_continuous_chk = QCheckBox("Use continuous phenotype values?")
+        self.use_continuous_chk.setToolTip(
+            "Run ESL-PSC with continuous response variables using sg_lasso_leastr."
+        )
+
+        def _on_use_cont_toggled(checked: bool) -> None:
+            setattr(self.config, 'use_continuous_phenotypes', checked)
+            if hasattr(self, '_update_sps_plot_state'):
+                self._update_sps_plot_state()
+            # Also refresh visibility/enabled state of dependent widgets
+            self.update_output_options_state()
+
+        self.use_continuous_chk.toggled.connect(_on_use_cont_toggled)
+        output_layout.addWidget(self.use_continuous_chk)
         
         # Connect output type changes to enable/disable SPS plot options
         def update_sps_plot_state():
@@ -320,6 +336,7 @@ class ParametersPage(BaseWizardPage):
             cont_visible = (
                 not self.genes_only_btn.isChecked()
                 and cont_active
+                and not getattr(self.config, 'response_matrices_are_continuous', False)
             )
             self.continuous_plot_chk.setVisible(cont_visible)
             if not cont_visible:
@@ -1125,6 +1142,22 @@ class ParametersPage(BaseWizardPage):
             # so do not override it here. Just refresh the SPS plot/density UI.
             if hasattr(self, '_update_sps_plot_state'):
                 self._update_sps_plot_state()
+
+            # Show/enable continuous phenotype toggle based on config
+            if hasattr(self, 'use_continuous_chk'):
+                if getattr(self.config, 'response_matrices_are_continuous', False):
+                    # When response matrices are already continuous, lock checkbox on
+                    self.use_continuous_chk.setVisible(True)
+                    self.use_continuous_chk.setChecked(True)
+                    self.use_continuous_chk.setEnabled(False)
+                else:
+                    cont_detected = bool(getattr(self.config, 'species_pheno_is_continuous', False))
+                    self.use_continuous_chk.setVisible(cont_detected)
+                    self.use_continuous_chk.setEnabled(cont_detected)
+                    if cont_detected:
+                        self.use_continuous_chk.setChecked(
+                            bool(getattr(self.config, 'use_continuous_phenotypes', False))
+                        )
 
         except RuntimeError:
             # Widgets have been deleted, ignore

--- a/gui/ui/widgets/results_display.py
+++ b/gui/ui/widgets/results_display.py
@@ -35,31 +35,50 @@ def _launch_site_viewer(gene: str, config, sites_path: str | None, parent=None) 
     # Load alignment records using shared FASTA reader for reliability/consistency
     records = read_fasta(align_path)
 
-    # Determine species groups from first response matrix
-    response_dir = config.response_dir
-    if not response_dir:
-        base = os.path.basename(config.species_groups_file).replace(".txt", "")
-        response_dir = os.path.join(config.output_dir, f"{base}_response_matrices")
-    if not os.path.isdir(response_dir):
-        raise FileNotFoundError(f"Response directory not found: {response_dir}")
-    files = sorted([f for f in os.listdir(response_dir) if f.endswith('.txt')])
-    if not files:
-        raise FileNotFoundError("No response matrices found")
-    first_matrix = os.path.join(response_dir, files[0])
+    # Determine species groups from species groups file if available
+    conv: list[str] = []
+    ctrl: list[str] = []
+    groups_path = getattr(config, "species_groups_file", "")
+    if groups_path and os.path.exists(groups_path):
+        try:
+            with open(groups_path) as fp:
+                lines = [ln.strip() for ln in fp if ln.strip()]
+            for idx in range(0, len(lines), 2):
+                conv_line = lines[idx]
+                conv.extend([sp.strip() for sp in conv_line.split(',') if sp.strip()])
+                if idx + 1 < len(lines):
+                    ctrl_line = lines[idx + 1]
+                    ctrl.extend([sp.strip() for sp in ctrl_line.split(',') if sp.strip()])
+        except Exception:
+            conv = []
+            ctrl = []
 
-    conv = []
-    ctrl = []
-    with open(first_matrix) as f:
-        for line in f:
-            sp, val = line.strip().split()[:2]
-            if val == '1':
-                conv.append(sp)
-            else:
-                ctrl.append(sp)
+    # Fallback to response matrices when species groups file is absent
+    if not conv and not ctrl:
+        response_dir = config.response_dir
+        if not response_dir:
+            base = os.path.basename(getattr(config, "species_groups_file", "")).replace(".txt", "")
+            response_dir = os.path.join(config.output_dir, f"{base}_response_matrices")
+        if not os.path.isdir(response_dir):
+            raise FileNotFoundError(f"Response directory not found: {response_dir}")
+        files = sorted([f for f in os.listdir(response_dir) if f.endswith('.txt')])
+        if not files:
+            raise FileNotFoundError("No response matrices found")
+        first_matrix = os.path.join(response_dir, files[0])
+        with open(first_matrix) as f:
+            for line in f:
+                sp, val = line.strip().split()[:2]
+                if val == '1':
+                    conv.append(sp)
+                else:
+                    ctrl.append(sp)
+
+    conv = sorted(dict.fromkeys(conv))
+    ctrl = sorted(dict.fromkeys(ctrl))
 
     # ─── Phenotype data ───────────────────────────────────────────────
-    species_pheno_map: dict[str, int] | None = None
-    pheno_name_map: dict[int, str] | None = None
+    species_pheno_map: dict[str, float] | None = None
+    pheno_name_map: dict[float, str] | None = None
     pheno_path = getattr(config, "species_phenotypes_file", "")
     if pheno_path and os.path.exists(pheno_path):
         try:
@@ -70,16 +89,15 @@ def _launch_site_viewer(gene: str, config, sites_path: str | None, parent=None) 
                     if len(parts) >= 2:
                         sp, val = parts[0], parts[1]
                         try:
-                            species_pheno_map[sp] = int(val)
+                            species_pheno_map[sp] = float(val)
                         except ValueError:
-                            # Skip malformed phenotype value
                             continue
         except Exception:
             species_pheno_map = None
 
     # Phenotype display names from config
     if hasattr(config, "pheno_name1") and hasattr(config, "pheno_name2"):
-        pheno_name_map = {1: str(config.pheno_name1), -1: str(config.pheno_name2)}
+        pheno_name_map = {1.0: str(config.pheno_name1), -1.0: str(config.pheno_name2)}
 
     all_sites_info = None
     pss_map = {}

--- a/gui/ui/widgets/site_viewer.py
+++ b/gui/ui/widgets/site_viewer.py
@@ -44,8 +44,8 @@ class SiteViewer(QWidget):
         pss_scores: Dict[int, float] | None = None,
         parent=None,
         # Optional phenotype information
-        species_pheno_map: Dict[str, int] | None = None,
-        pheno_name_map: Dict[int, str] | None = None,
+        species_pheno_map: Dict[str, float] | None = None,
+        pheno_name_map: Dict[float, str] | None = None,
     ) -> None:
         super().__init__(parent)
 
@@ -88,16 +88,16 @@ class SiteViewer(QWidget):
 
         # ─── Phenotype maps ───────────────────────────────────────────────
         # Mapping of species → phenotype value (1/-1)
-        self.species_pheno_map: Dict[str, int] = species_pheno_map or {}
+        self.species_pheno_map: Dict[str, float] = species_pheno_map or {}
         # Mapping of phenotype value (1/-1) → display name (e.g. "C4", "C3")
-        default_pheno_map = {1: "1", -1: "-1"}
+        default_pheno_map = {1.0: "1", -1.0: "-1"}
         # Build phenotype display names mapping avoiding Python 3.9+ dict union
-        self.pheno_name_map: Dict[int, str] = default_pheno_map.copy()
+        self.pheno_name_map: Dict[float, str] = default_pheno_map.copy()
         if pheno_name_map:
             self.pheno_name_map.update(pheno_name_map)
 
         # Cache the phenotype value considered "convergent" (defaults to +1)
-        self.convergent_pheno_value: int = 1
+        self.convergent_pheno_value: float = 1.0
 
         if all_sites_info is None:
             all_sites_info = [


### PR DESCRIPTION
## Summary
- Determine convergent and control species from the species groups file and support float phenotypes when launching the site viewer
- Annotate species with their phenotype values inside the site viewer
- Expose and synchronize continuous-phenotype controls in the Parameters page

## Testing
- `flake8 --select=F --exclude additional_code .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b600eeea048327a9697487ffc8cb7a