### PR TITLE
feat: add continuous phenotype auto selection

### DIFF
--- a/gui/ui/widgets/dialogs.py
+++ b/gui/ui/widgets/dialogs.py
@@ -1,6 +1,18 @@
 from __future__ import annotations
 
-from PySide6.QtWidgets import QMessageBox
+from typing import Sequence
+
+from PySide6.QtWidgets import (
+    QMessageBox,
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QDialogButtonBox,
+    QLabel,
+    QDoubleSpinBox,
+)
+
+from gui.ui.widgets.histogram_canvas import HistogramCanvas
 
 
 class AutoSelectOptionsDialog(QMessageBox):
@@ -64,3 +76,59 @@ class AutoSelectOptionsDialog(QMessageBox):
         """Treat window close as cancel."""
         self.choice = None
         super().closeEvent(event)
+
+
+class PhenoThresholdDialog(QDialog):
+    """Dialog for choosing thresholds for continuous phenotypes."""
+
+    def __init__(self, values: Sequence[float], parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Phenotype Thresholds")
+        layout = QVBoxLayout(self)
+
+        form = QHBoxLayout()
+        form.addWidget(QLabel("Lower threshold:"))
+        self.lower_spin = QDoubleSpinBox()
+        form.addWidget(self.lower_spin)
+        form.addWidget(QLabel("Upper threshold:"))
+        self.upper_spin = QDoubleSpinBox()
+        form.addWidget(self.upper_spin)
+        layout.addLayout(form)
+
+        self.values = list(values)
+        if self.values:
+            vmin, vmax = min(self.values), max(self.values)
+        else:
+            vmin, vmax = 0.0, 1.0
+        self.lower_spin.setRange(vmin, vmax)
+        self.upper_spin.setRange(vmin, vmax)
+        self.lower_spin.setDecimals(3)
+        self.upper_spin.setDecimals(3)
+        self.lower_spin.setValue(vmin)
+        self.upper_spin.setValue(vmax)
+
+        self.canvas = HistogramCanvas(self, width=4, height=2, dpi=100)
+        layout.addWidget(self.canvas)
+
+        self.lower_spin.valueChanged.connect(self._update_plot)
+        self.upper_spin.valueChanged.connect(self._update_plot)
+
+        btns = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        btns.accepted.connect(self.accept)
+        btns.rejected.connect(self.reject)
+        layout.addWidget(btns)
+
+        self._update_plot()
+
+    def _update_plot(self) -> None:
+        self.canvas.plot_values(
+            self.values, self.lower_spin.value(), self.upper_spin.value()
+        )
+
+    @property
+    def lower_threshold(self) -> float:
+        return self.lower_spin.value()
+
+    @property
+    def upper_threshold(self) -> float:
+        return self.upper_spin.value()

--- a/gui/ui/widgets/histogram_canvas.py
+++ b/gui/ui/widgets/histogram_canvas.py
@@ -44,3 +44,39 @@ class HistogramCanvas(FigureCanvasQTAgg):
         )
         self.axes.legend()
         self.draw()
+
+    def plot_values(
+        self, values: Sequence[float], lower: float, upper: float
+    ) -> None:
+        """Plot a histogram of phenotype values with threshold lines."""
+        self.axes.clear()
+
+        if not values:
+            self.draw()
+            return
+
+        self.axes.hist(
+            values,
+            bins="auto",
+            color="lightblue",
+            edgecolor="black",
+        )
+        self.axes.axvline(
+            x=lower,
+            color="red",
+            linestyle="--",
+            label=f"Lower = {lower:.3g}",
+        )
+        self.axes.axvline(
+            x=upper,
+            color="green",
+            linestyle="--",
+            label=f"Upper = {upper:.3g}",
+        )
+        self.axes.set(
+            xlabel="Phenotype Value",
+            ylabel="Count of Species",
+            title="Phenotype Value Distribution",
+        )
+        self.axes.legend()
+        self.draw()

--- a/gui/ui/widgets/tree_viewer.py
+++ b/gui/ui/widgets/tree_viewer.py
@@ -26,6 +26,7 @@ from PySide6.QtWidgets import (
     QMenu,
     QSizePolicy,
     QProgressDialog,
+    QDialog,
 )
 from PySide6.QtGui import (
     QPainter,
@@ -48,6 +49,7 @@ from gui.ui.widgets.graphics_view import ZoomableGraphicsView
 from gui.ui.widgets.label_items import HoverLabelItem
 from gui.ui.widgets.dialogs import (
     AutoSelectOptionsDialog as AutoSelectOptionsDialogExt,
+    PhenoThresholdDialog,
 )
 
 
@@ -1238,6 +1240,39 @@ class TreeViewer(QWidget):
     # ------------------------------------------------------------------
     def _auto_select_pairs(self) -> None:
         """Automatically choose contrast pairs based on phenotype transitions."""
+        if self._continuous_pheno:
+            dlg_thresh = PhenoThresholdDialog(
+                list(self._phenotypes.values()), parent=self
+            )
+            if dlg_thresh.exec() != QDialog.DialogCode.Accepted:
+                return
+            lower = dlg_thresh.lower_threshold
+            upper = dlg_thresh.upper_threshold
+            if lower >= upper:
+                QMessageBox.warning(
+                    self,
+                    "Threshold Error",
+                    "Lower threshold must be less than upper threshold",
+                )
+                return
+            self._phenotypes = {
+                name: 1 if val >= upper else -1
+                for name, val in self._phenotypes.items()
+                if val >= upper or val <= lower
+            }
+            self._update_pheno_mode_and_range()
+            self._reset_scene()
+            self._draw_tree(self._tree)
+            self._apply_pairs()
+            self._update_auto_btn()
+            if sum(1 for v in self._phenotypes.values() if v in (1, -1)) < 4:
+                QMessageBox.warning(
+                    self,
+                    "Threshold Error",
+                    "Not enough species outside the thresholds for auto-selection",
+                )
+                return
+
         # Ask user how to resolve ambiguous choices
         dlg = AutoSelectOptionsDialogExt(bool(self._alignments_dir), parent=self)
         dlg.exec()


### PR DESCRIPTION
## Summary
- allow automatic contrast-pair selection for continuous phenotypes by thresholding
- show distribution of phenotype values with adjustable thresholds
- support plotting phenotype histograms

## Testing
- `flake8 --select=F --exclude additional_code .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ba2c7ef580832795f52a9276d2bf67