### PR TITLE
Add fast scan feature

### DIFF
--- a/gui/core/fast_scan.py
+++ b/gui/core/fast_scan.py
@@ -1,0 +1,121 @@
+"""Fast scanning of alignments for CCS and control convergence."""
+from __future__ import annotations
+
+import os
+from collections import Counter
+from typing import Callable, Dict, List
+
+from gui.core.fasta_io import read_fasta
+
+
+def _parse_species_groups(path: str) -> List[tuple[List[str], List[str]]]:
+    """Return list of (convergent_species, control_species) combos."""
+    combos: List[tuple[List[str], List[str]]] = []
+    if not path or not os.path.exists(path):
+        return combos
+    lines: List[str] = []
+    with open(path, encoding="utf-8", errors="ignore") as fh:
+        lines = [ln.strip() for ln in fh if ln.strip()]
+    for i in range(0, len(lines), 2):
+        conv_line = lines[i]
+        ctrl_line = lines[i + 1] if i + 1 < len(lines) else ""
+        conv = [sp.strip() for sp in conv_line.replace(",", " ").split() if sp.strip()]
+        ctrl = [sp.strip() for sp in ctrl_line.replace(",", " ").split() if sp.strip()]
+        combos.append((conv, ctrl))
+    return combos
+
+
+def list_species(alignment_dir: str) -> List[str]:
+    """Collect all species names present across alignment files."""
+    species: set[str] = set()
+    if not alignment_dir or not os.path.isdir(alignment_dir):
+        return []
+    for fname in os.listdir(alignment_dir):
+        if not fname.endswith(".fas"):
+            continue
+        for rec_id, _ in read_fasta(os.path.join(alignment_dir, fname)):
+            species.add(rec_id)
+    return sorted(species)
+
+
+def fast_scan_alignments(
+    alignment_dir: str,
+    species_groups_file: str,
+    outgroup_species: str,
+    progress_cb: Callable[[int, int], None] | None = None,
+) -> List[Dict[str, float]]:
+    """Scan all alignments and compute convergence metrics per gene.
+
+    Parameters
+    ----------
+    alignment_dir: str
+        Directory containing ``.fas`` alignment files.
+    species_groups_file: str
+        Path to species groups definition.
+    outgroup_species: str
+        Species to treat as the outgroup.
+    progress_cb: callable, optional
+        Callback receiving ``(current, total)`` file counts.
+    """
+    combos = _parse_species_groups(species_groups_file)
+    files = sorted([f for f in os.listdir(alignment_dir) if f.endswith(".fas")])
+    results: List[Dict[str, float]] = []
+    total = len(files)
+    for idx, fname in enumerate(files, 1):
+        path = os.path.join(alignment_dir, fname)
+        records = read_fasta(path)
+        species_seq = {sp: seq for sp, seq in records}
+        if not species_seq:
+            if progress_cb:
+                progress_cb(idx, total)
+            continue
+        seq_len = len(next(iter(species_seq.values())))
+        true_counts: List[int] = []
+        ctrl_counts: List[int] = []
+        for conv, ctrl in combos:
+            ccs = 0
+            ctrl_conv = 0
+            for pos in range(seq_len):
+                conv_aa = [species_seq.get(sp, "?")[pos] for sp in conv]
+                ctrl_aa = [species_seq.get(sp, "?")[pos] for sp in ctrl]
+                out_aa = [species_seq.get(outgroup_species, "?")[pos]]
+                clean_conv = [x for x in conv_aa if x not in ("?", "-")]
+                clean_ctrl = [x for x in ctrl_aa if x not in ("?", "-")]
+                clean_out = [x for x in out_aa if x not in ("?", "-")]
+                if (
+                    clean_ctrl
+                    and clean_out
+                    and len(set(clean_ctrl)) == 1
+                    and len(set(clean_out)) == 1
+                    and list(set(clean_ctrl))[0] == list(set(clean_out))[0]
+                ):
+                    ctrl_res = clean_ctrl[0]
+                    conv_counter = Counter(clean_conv)
+                    for res, cnt in conv_counter.items():
+                        if res != ctrl_res and cnt >= 2:
+                            ccs += 1
+                            break
+                if clean_out and len(set(clean_out)) == 1:
+                    out_res = clean_out[0]
+                    if clean_conv and all(r == out_res for r in clean_conv):
+                        ctrl_counter = Counter(clean_ctrl)
+                        for res, cnt in ctrl_counter.items():
+                            if res != out_res and cnt >= 2:
+                                ctrl_conv += 1
+                                break
+            true_counts.append(ccs)
+            ctrl_counts.append(ctrl_conv)
+        avg_true = sum(true_counts) / len(combos) if combos else 0.0
+        avg_ctrl = sum(ctrl_counts) / len(combos) if combos else 0.0
+        results.append(
+            {
+                "gene": os.path.splitext(fname)[0],
+                "avg_true": avg_true,
+                "avg_control": avg_ctrl,
+                "diff": avg_true - avg_ctrl,
+            }
+        )
+        if progress_cb:
+            progress_cb(idx, total)
+    results.sort(key=lambda x: x["avg_true"], reverse=True)
+    return results

--- a/gui/ui/pages/input_page.py
+++ b/gui/ui/pages/input_page.py
@@ -2,9 +2,10 @@
 from PySide6.QtWidgets import (
     QScrollArea, QWidget, QVBoxLayout, QGroupBox, QFrame, QRadioButton,
     QLabel, QButtonGroup, QFormLayout, QPushButton, QFileDialog, QMessageBox,
-    QSizePolicy, QCheckBox
+    QSizePolicy, QProgressDialog, QHBoxLayout
 )
 from PySide6.QtCore import Qt  # Needed for alignment
+from PySide6.QtWidgets import QApplication
 
 # New helper for viewing completed runs
 from gui.ui.widgets.existing_output_viewer import select_and_show_existing_output
@@ -14,6 +15,9 @@ from esl_psc_cli import esl_psc_functions as ecf
 
 from gui.ui.widgets.file_selectors import FileSelector
 from gui.ui.widgets.tree_viewer import TreeViewer
+from gui.ui.widgets.dialogs import OutgroupDialog
+from gui.ui.widgets.results_display import FastScanResultsDialog
+from gui.core import fast_scan
 from Bio import Phylo
 from .base_page import BaseWizardPage
 
@@ -39,12 +43,21 @@ class InputPage(BaseWizardPage):
         container_layout = QVBoxLayout(container)
         container_layout.setContentsMargins(0, 0, 0, 0)
 
-        # ─── Load Existing Output Button (top-left) ────────────────────
+        # ─── Top Buttons (Fast Scan + Load Existing Output) ────────────
+        top_btns = QHBoxLayout()
+        fast_btn = QPushButton("Fast Scan")
+        fast_btn.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        fast_btn.setToolTip("Quickly scan alignments for convergence signals.")
+        fast_btn.clicked.connect(self._on_fast_scan)
+        top_btns.addWidget(fast_btn)
+
         load_prev_btn = QPushButton("Load and View Existing Output")
         load_prev_btn.setToolTip("Select an output folder from a completed ESL-PSC run to view its results.")
         load_prev_btn.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         load_prev_btn.clicked.connect(lambda *_: select_and_show_existing_output(parent=self))
-        container_layout.addWidget(load_prev_btn, alignment=Qt.AlignmentFlag.AlignRight)
+        top_btns.addWidget(load_prev_btn)
+        top_btns.setAlignment(Qt.AlignmentFlag.AlignRight)
+        container_layout.addLayout(top_btns)
         
         # Required inputs group
         req_group = QGroupBox("Required Inputs")
@@ -243,9 +256,44 @@ class InputPage(BaseWizardPage):
         
         # Add stretch to push everything to the top
         container_layout.addStretch()
-        
+
         # Add the scroll area to the page's layout
         self.layout().addWidget(scroll)
+
+    def _on_fast_scan(self):
+        """Run a quick convergence scan of the alignments."""
+        align_dir = getattr(self.config, 'alignments_dir', '')
+        groups_file = getattr(self.config, 'species_groups_file', '')
+        if not align_dir or not os.path.isdir(align_dir):
+            QMessageBox.warning(self, "Fast Scan", "Please select an alignment directory first.")
+            return
+        if not groups_file or not os.path.exists(groups_file):
+            QMessageBox.warning(self, "Fast Scan", "Please select a species groups file first.")
+            return
+        species = fast_scan.list_species(align_dir)
+        if not species:
+            QMessageBox.warning(self, "Fast Scan", "No species found in alignments.")
+            return
+        dlg = OutgroupDialog(species, self)
+        if dlg.exec() != dlg.Accepted:
+            return
+        outgroup = dlg.selected
+        progress = QProgressDialog("Scanning alignments...", None, 0, 1, self)
+        progress.setWindowTitle("Fast Scan")
+        progress.setAutoClose(True)
+        progress.show()
+
+        def update(cur, total):
+            progress.setMaximum(total)
+            progress.setValue(cur)
+            QApplication.processEvents()
+
+        results = fast_scan.fast_scan_alignments(align_dir, groups_file, outgroup, update)
+        progress.close()
+        if not results:
+            QMessageBox.information(self, "Fast Scan", "No results produced.")
+            return
+        FastScanResultsDialog.show_results(results, self.config, outgroup, parent=self)
 
     def open_newick_tree(self):
         """Open a Newick file and display it in a tree viewer."""

--- a/gui/ui/widgets/dialogs.py
+++ b/gui/ui/widgets/dialogs.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Sequence
 
 from PySide6.QtWidgets import (
-    QMessageBox,
     QDialog,
     QVBoxLayout,
     QHBoxLayout,
@@ -11,6 +10,7 @@ from PySide6.QtWidgets import (
     QLabel,
     QDoubleSpinBox,
     QPushButton,
+    QComboBox,
 )
 
 from gui.ui.widgets.histogram_canvas import HistogramCanvas
@@ -153,3 +153,24 @@ class PhenoThresholdDialog(QDialog):
     @property
     def upper_threshold(self) -> float:
         return self.upper_spin.value()
+
+
+class OutgroupDialog(QDialog):
+    """Dialog to pick an outgroup species."""
+
+    def __init__(self, species: Sequence[str], parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Select Outgroup Species")
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Choose outgroup species:"))
+        self._combo = QComboBox()
+        self._combo.addItems(list(species))
+        layout.addWidget(self._combo)
+        btns = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        btns.accepted.connect(self.accept)
+        btns.rejected.connect(self.reject)
+        layout.addWidget(btns)
+
+    @property
+    def selected(self) -> str:
+        return self._combo.currentText()

--- a/gui/ui/widgets/results_display.py
+++ b/gui/ui/widgets/results_display.py
@@ -13,7 +13,7 @@ from PySide6.QtWidgets import (
     QDialog, QVBoxLayout, QSizePolicy, QTableWidget, QTableWidgetItem,
     QAbstractItemView, QTreeWidget, QTreeWidgetItem, QMessageBox,
     QLabel, QHeaderView, QPushButton, QHBoxLayout,
-    QComboBox, QDialogButtonBox
+    QComboBox, QDialogButtonBox, QFileDialog
 )
 from PySide6.QtSvgWidgets import QSvgWidget
 
@@ -24,7 +24,13 @@ from gui.ui.widgets.site_viewer import SiteViewer
 _open_dialogs = []
 
 
-def _launch_site_viewer(gene: str, config, sites_path: str | None, parent=None) -> None:
+def _launch_site_viewer(
+    gene: str,
+    config,
+    sites_path: str | None,
+    parent=None,
+    outgroup_species: list[str] | None = None,
+) -> None:
     """Open the SiteViewer window for the given gene."""
     align_dir = getattr(config, "alignments_dir", "")
     if not align_dir:
@@ -156,7 +162,7 @@ def _launch_site_viewer(gene: str, config, sites_path: str | None, parent=None) 
         records,
         conv,
         ctrl,
-        [],  # outgroup species (not derived here)
+        outgroup_species or [],
         gene,
         all_sites_info,
         False,
@@ -633,5 +639,72 @@ class SelectedSitesDialog(QDialog):
             gene_order = list(dict.fromkeys(df["gene_name"]))[:200]
 
         dialog = SelectedSitesDialog(df, gene_order, alignments_dir, parent)
+        dialog.show()
+        _open_dialogs.append(dialog)
+
+class FastScanResultsDialog(QDialog):
+    """Display fast scan gene rankings."""
+
+    def __init__(self, results, config, outgroup, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Fast Scan Results")
+        self.config = config
+        self.outgroup = outgroup
+        layout = QVBoxLayout(self)
+
+        header = QHBoxLayout()
+        label = QLabel("Double-click a gene to open the Site Viewer.")
+        header.addWidget(label)
+        header.addStretch()
+        save_btn = QPushButton("Save Results")
+        save_btn.clicked.connect(self._save_results)
+        header.addWidget(save_btn)
+        layout.addLayout(header)
+
+        self.table = QTableWidget()
+        self.table.setColumnCount(4)
+        self.table.setHorizontalHeaderLabels([
+            "Gene", "Avg True Convergence", "Avg Control Convergence", "Avg True - Control",
+        ])
+        self.table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.table.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.table.doubleClicked.connect(lambda idx: self._open_site_viewer(idx.row()))
+        layout.addWidget(self.table)
+
+        self.results_df = pd.DataFrame(results)
+        top = self.results_df.head(200)
+        self.table.setRowCount(len(top))
+        for row_idx, (_, row) in enumerate(top.iterrows()):
+            self.table.setItem(row_idx, 0, QTableWidgetItem(str(row["gene"])))
+            self.table.setItem(row_idx, 1, QTableWidgetItem(f"{row['avg_true']:.5f}"))
+            self.table.setItem(row_idx, 2, QTableWidgetItem(f"{row['avg_control']:.5f}"))
+            self.table.setItem(row_idx, 3, QTableWidgetItem(f"{row['diff']:.5f}"))
+        self.table.resizeColumnsToContents()
+        self.resize(800, 600)
+
+    def _open_site_viewer(self, row: int) -> None:
+        gene_item = self.table.item(row, 0)
+        if gene_item is None:
+            return
+        gene = gene_item.text()
+        try:
+            _launch_site_viewer(gene, self.config, None, parent=self, outgroup_species=[self.outgroup])
+        except Exception as e:
+            QMessageBox.critical(self, "Error", f"Failed to open Site Viewer:\n{e}")
+
+    def _save_results(self) -> None:
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Save Fast Scan Results", "fast_scan_results.csv", "CSV Files (*.csv)"
+        )
+        if path:
+            try:
+                self.results_df.to_csv(path, index=False)
+            except Exception as e:
+                QMessageBox.critical(self, "Error", f"Could not save results:\n{e}")
+
+    @staticmethod
+    def show_results(results, config, outgroup, parent=None):
+        dialog = FastScanResultsDialog(results, config, outgroup, parent)
         dialog.show()
         _open_dialogs.append(dialog)


### PR DESCRIPTION
## Summary
- add fast scan logic to scan alignments for CCS and control convergence
- add Fast Scan button on input page to trigger quick convergence analysis
- show Fast Scan results with saveable table and outgroup selection dialog

## Testing
- `flake8 --select=F --exclude additional_code .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68be3a62fa608327a75667a741a793cd