### PR TITLE
Add variable site counts to fast scan results

### DIFF
--- a/gui/core/fast_scan.py
+++ b/gui/core/fast_scan.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import os
-import itertools
 from collections import Counter
 from typing import Callable, Dict, List
 
@@ -10,6 +9,9 @@ from gui.core.fasta_io import read_fasta
 from esl_psc_cli.deletion_canceler import (
     parse_species_groups as cli_parse_species_groups,
 )
+from esl_psc_cli.esl_psc_functions import count_var_sites
+from Bio.Seq import Seq
+from Bio.SeqRecord import SeqRecord
 
 
 def _parse_species_groups(path: str) -> List[tuple[List[str], List[str]]]:
@@ -52,7 +54,7 @@ def fast_scan_alignments(
     outgroup_species: str,
     progress_cb: Callable[[int, int], None] | None = None,
     response_dir: str | None = None,
-) -> List[Dict[str, float]]:
+) -> List[Dict[str, float | int]]:
     """Scan all alignments and compute convergence metrics per gene.
 
     Parameters
@@ -73,6 +75,7 @@ def fast_scan_alignments(
     for idx, fname in enumerate(files, 1):
         path = os.path.join(alignment_dir, fname)
         records = read_fasta(path)
+        seq_records = [SeqRecord(Seq(seq), id=sp) for sp, seq in records]
         species_seq = {sp: seq for sp, seq in records}
         if not species_seq:
             if progress_cb:
@@ -160,12 +163,14 @@ def fast_scan_alignments(
 
         avg_true = (sum(true_counts) / true_den) if true_den else 0.0
         avg_ctrl = (sum(ctrl_counts) / ctrl_den) if ctrl_den else 0.0
+        var_sites = count_var_sites(seq_records)
         results.append(
             {
                 "gene": os.path.splitext(fname)[0],
                 "avg_true": avg_true,
                 "avg_control": avg_ctrl,
                 "diff": avg_true - avg_ctrl,
+                "variable_sites": var_sites,
             }
         )
         if progress_cb:

--- a/gui/ui/widgets/results_display.py
+++ b/gui/ui/widgets/results_display.py
@@ -775,9 +775,10 @@ class FastScanResultsDialog(QDialog):
         layout.addLayout(header)
 
         self.table = QTableWidget()
-        self.table.setColumnCount(4)
+        self.table.setColumnCount(5)
         self.table.setHorizontalHeaderLabels([
             "Gene",
+            "Variable Sites",
             "Avg True Convergence",
             "Avg Control Convergence",
             "Avg True - Control",
@@ -814,12 +815,14 @@ class FastScanResultsDialog(QDialog):
             # Gene column – regular text item
             self.table.setItem(row_idx, 0, QTableWidgetItem(str(row["gene"])) )
             # Numeric columns – use NumericItem for proper sorting
+            v_sites = float(row['variable_sites']) if pd.notna(row['variable_sites']) else float('nan')
             v1 = float(row['avg_true']) if pd.notna(row['avg_true']) else float('nan')
             v2 = float(row['avg_control']) if pd.notna(row['avg_control']) else float('nan')
             v3 = float(row['diff']) if pd.notna(row['diff']) else float('nan')
-            self.table.setItem(row_idx, 1, NumericItem(v1, _fmt_num(v1)))
-            self.table.setItem(row_idx, 2, NumericItem(v2, _fmt_num(v2)))
-            self.table.setItem(row_idx, 3, NumericItem(v3, _fmt_num(v3)))
+            self.table.setItem(row_idx, 1, NumericItem(v_sites, _fmt_num(v_sites)))
+            self.table.setItem(row_idx, 2, NumericItem(v1, _fmt_num(v1)))
+            self.table.setItem(row_idx, 3, NumericItem(v2, _fmt_num(v2)))
+            self.table.setItem(row_idx, 4, NumericItem(v3, _fmt_num(v3)))
         self.table.resizeColumnsToContents()
         self.resize(800, 600)
         # Make Save Results the default and focused button

--- a/tests/test_fast_scan_avg_fractional.py
+++ b/tests/test_fast_scan_avg_fractional.py
@@ -1,5 +1,7 @@
-import os
 from gui.core import fast_scan
+from esl_psc_cli.esl_psc_functions import count_var_sites
+from Bio.Seq import Seq
+from Bio.SeqRecord import SeqRecord
 
 def write_fasta(path: str, records):
     with open(path, 'w') as f:
@@ -50,3 +52,7 @@ def test_fast_scan_averages_fractional(tmp_path):
     assert abs(rec["avg_true"] - 2.5) < 1e-6, f"Expected avg_true=2.5, got {rec['avg_true']}"
     # No control-convergence sites in this synthetic design
     assert abs(rec["avg_control"] - 0.0) < 1e-6, f"Expected avg_control=0.0, got {rec['avg_control']}"
+
+    # Variable sites count should match CLI logic
+    expected_var = count_var_sites([SeqRecord(Seq(seq), id=name) for name, seq in records])
+    assert rec["variable_sites"] == expected_var


### PR DESCRIPTION
## Summary
- include variable site counts for each gene during fast scan using existing CLI logic
- display variable site counts in Fast Scan results table
- test fast scan for correct variable site counting

## Testing
- `flake8 --select=F --exclude additional_code .`
- `pytest tests/test_fast_scan_avg_fractional.py -q`
- `pytest tests/test_gui_smoke.py -q`
- `pytest tests/test_cli_smoke.py -q`
- `pytest tests/test_cli_continuous.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68bed9965f7c8327993449f357a35009