### PR TITLE
Add Site Viewer button with combo memory

### DIFF
--- a/gui/core/config.py
+++ b/gui/core/config.py
@@ -2,7 +2,7 @@
 Configuration model for ESL-PSC analysis.
 """
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional, Tuple
 import os
 
 @dataclass
@@ -28,6 +28,9 @@ class ESLConfig:
     # Session-level memory (not written to CLI args)
     # Remembers the last outgroup species selected in the Fast Scan dialog
     last_fast_scan_outgroup: str = ""
+    # Remembers the last species combination chosen for Site Viewer
+    preferred_groups_combo: Optional[Tuple[List[str], List[str]]] = None
+    preferred_response_matrix: str = ""
 
     # ─── Hyper-parameters ───────────────────────────────────────────────────────
     initial_lambda1: float = 0.01

--- a/gui/ui/pages/input_page.py
+++ b/gui/ui/pages/input_page.py
@@ -2,7 +2,8 @@
 from PySide6.QtWidgets import (
     QScrollArea, QWidget, QVBoxLayout, QGroupBox, QFrame, QRadioButton,
     QLabel, QButtonGroup, QFormLayout, QPushButton, QFileDialog, QMessageBox,
-    QSizePolicy, QProgressDialog, QHBoxLayout, QDialog
+    QSizePolicy, QProgressDialog, QHBoxLayout, QDialog, QComboBox,
+    QDialogButtonBox
 )
 from PySide6.QtCore import Qt  # Needed for alignment
 from PySide6.QtWidgets import QApplication
@@ -16,7 +17,11 @@ from esl_psc_cli import esl_psc_functions as ecf
 from gui.ui.widgets.file_selectors import FileSelector
 from gui.ui.widgets.tree_viewer import TreeViewer
 from gui.ui.widgets.dialogs import OutgroupDialog
-from gui.ui.widgets.results_display import FastScanResultsDialog
+from gui.ui.widgets.results_display import (
+    FastScanResultsDialog,
+    _select_combo_from_groups,
+    _launch_site_viewer,
+)
 from gui.core import fast_scan
 from Bio import Phylo
 from .base_page import BaseWizardPage
@@ -43,7 +48,7 @@ class InputPage(BaseWizardPage):
         container_layout = QVBoxLayout(container)
         container_layout.setContentsMargins(0, 0, 0, 0)
 
-        # ─── Top Buttons (Fast Scan + Load Existing Output) ────────────
+        # ─── Top Buttons (Load Existing Output, Site Viewer, Fast Scan) ────────────
         top_btns = QHBoxLayout()
         fast_btn = QPushButton("Fast Scan")
         fast_btn.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
@@ -54,8 +59,14 @@ class InputPage(BaseWizardPage):
         load_prev_btn.setToolTip("Select an output folder from a completed ESL-PSC run to view its results.")
         load_prev_btn.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         load_prev_btn.clicked.connect(lambda *_: select_and_show_existing_output(parent=self))
-        # Add 'Load Existing Output' first, then 'Fast Scan' so Fast Scan appears to the right
+
+        site_view_btn = QPushButton("Site Viewer")
+        site_view_btn.setToolTip("View an alignment with a chosen species combo.")
+        site_view_btn.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        site_view_btn.clicked.connect(self._on_site_viewer)
+        # Add 'Load Existing Output', then 'Site Viewer', then 'Fast Scan'
         top_btns.addWidget(load_prev_btn)
+        top_btns.addWidget(site_view_btn)
         top_btns.addWidget(fast_btn)
         top_btns.setAlignment(Qt.AlignmentFlag.AlignRight)
         container_layout.addLayout(top_btns)
@@ -141,9 +152,7 @@ class InputPage(BaseWizardPage):
                 "..."
             )
         )
-        self.species_groups.path_changed.connect(
-            lambda p: setattr(self.config, 'species_groups_file', p)
-        )
+        self.species_groups.path_changed.connect(self._on_species_groups_changed)
         self.input_files_layout.addWidget(self.species_groups)
 
         # Button to open a Newick tree viewer
@@ -260,6 +269,120 @@ class InputPage(BaseWizardPage):
 
         # Add the scroll area to the page's layout
         self.layout().addWidget(scroll)
+
+    def _on_site_viewer(self):
+        """Open the Site Viewer for a chosen alignment."""
+        groups_path = getattr(self.config, 'species_groups_file', '')
+        resp_dir = getattr(self.config, 'response_dir', '')
+        if not (groups_path and os.path.exists(groups_path)) and not (
+            resp_dir and os.path.isdir(resp_dir)
+        ):
+            QMessageBox.warning(
+                self,
+                "Site Viewer",
+                "Please select a species groups file or a response matrix directory first.",
+            )
+            return
+        align_dir = getattr(self.config, 'alignments_dir', '')
+        if not align_dir or not os.path.isdir(align_dir):
+            QMessageBox.warning(
+                self,
+                "Site Viewer",
+                "Please select an alignment directory first.",
+            )
+            return
+        path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Select Alignment File",
+            align_dir,
+            "FASTA Files (*.fas *.fasta *.fa)",
+        )
+        if not path:
+            return
+        gene = os.path.splitext(os.path.basename(path))[0]
+
+        # Choose species combination
+        if groups_path and os.path.exists(groups_path):
+            current = getattr(self.config, 'preferred_groups_combo', None)
+            res = _select_combo_from_groups(self, groups_path, current)
+            if not res:
+                return
+            self.config.preferred_groups_combo = res
+            self.config.preferred_response_matrix = ""
+            setattr(self, '_selected_groups_combo', res)
+            setattr(self, '_selected_response_matrix', "")
+        else:
+            files = sorted([f for f in os.listdir(resp_dir) if f.endswith('.txt')])
+            if not files:
+                QMessageBox.warning(self, "Site Viewer", "No response matrices found.")
+                return
+            dlg = QDialog(self)
+            dlg.setWindowTitle("Select Response Combo")
+            vbox = QVBoxLayout(dlg)
+            combo = QComboBox(dlg)
+            combo.addItems(files)
+            cur = getattr(self.config, 'preferred_response_matrix', '')
+            if cur and cur in files:
+                combo.setCurrentIndex(files.index(cur))
+            vbox.addWidget(combo)
+            conv_label = QLabel("Convergent species:")
+            conv_list = QLabel("")
+            conv_list.setWordWrap(True)
+            ctrl_label = QLabel("Control species:")
+            ctrl_list = QLabel("")
+            ctrl_list.setWordWrap(True)
+            vbox.addWidget(conv_label)
+            vbox.addWidget(conv_list)
+            vbox.addWidget(ctrl_label)
+            vbox.addWidget(ctrl_list)
+
+            def parse_species_lists(fname: str):
+                path = os.path.join(resp_dir, fname)
+                conv, ctrl = [], []
+                try:
+                    with open(path, encoding='utf-8', errors='ignore') as f:
+                        for idx, raw in enumerate(f):
+                            line = raw.strip()
+                            if not line:
+                                continue
+                            parts = line.split()
+                            if len(parts) < 2:
+                                continue
+                            sp = parts[0]
+                            if idx % 2 == 0:
+                                conv.append(sp)
+                            else:
+                                ctrl.append(sp)
+                except Exception:
+                    pass
+                return conv, ctrl
+
+            def refresh_lists():
+                fname = combo.currentText()
+                conv, ctrl = parse_species_lists(fname)
+                conv_list.setText("\n".join(conv) if conv else "(none)")
+                ctrl_list.setText("\n".join(ctrl) if ctrl else "(none)")
+
+            combo.currentIndexChanged.connect(lambda _i: refresh_lists())
+            refresh_lists()
+
+            buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel, parent=dlg)
+            vbox.addWidget(buttons)
+            buttons.accepted.connect(dlg.accept)
+            buttons.rejected.connect(dlg.reject)
+
+            if dlg.exec() != QDialog.Accepted:
+                return
+            selected = combo.currentText()
+            self.config.preferred_response_matrix = selected
+            self.config.preferred_groups_combo = None
+            setattr(self, '_selected_response_matrix', selected)
+            setattr(self, '_selected_groups_combo', None)
+
+        try:
+            _launch_site_viewer(gene, self.config, None, parent=self)
+        except Exception as e:
+            QMessageBox.critical(self, "Error", f"Failed to open Site Viewer:\n{e}")
 
     def _on_fast_scan(self):
         """Run a quick convergence scan of the alignments."""
@@ -455,9 +578,19 @@ class InputPage(BaseWizardPage):
             except Exception:
                 pass
 
+    def _on_species_groups_changed(self, path: str) -> None:
+        """Update config when species groups file changes and reset preferred combo."""
+        setattr(self.config, 'species_groups_file', path)
+        self.config.preferred_groups_combo = None
+        self.config.preferred_response_matrix = ""
+        setattr(self, '_selected_groups_combo', None)
+        setattr(self, '_selected_response_matrix', "")
+
     def _on_response_dir_changed(self, path: str) -> None:
         """Set response directory and detect continuous response matrices."""
         setattr(self.config, 'response_dir', path)
+        self.config.preferred_response_matrix = ""
+        self.config.preferred_groups_combo = None
         self.config.response_matrices_are_continuous = False
         if not path or not os.path.isdir(path):
             self.config.use_continuous_phenotypes = False
@@ -513,7 +646,7 @@ class InputPage(BaseWizardPage):
 
     def _update_groups_file(self, path: str) -> None:
         self.species_groups.set_path(path)
-        setattr(self.config, 'species_groups_file', path)
+        self._on_species_groups_changed(path)
 
     def _update_alignment_dir(self, path: str) -> None:
         """Update the alignment directory selector and config."""

--- a/gui/ui/widgets/results_display.py
+++ b/gui/ui/widgets/results_display.py
@@ -93,6 +93,15 @@ def _launch_site_viewer(
         conv = []
         ctrl = []
 
+    if not conv and not ctrl:
+        try:
+            pref = getattr(config, 'preferred_groups_combo', None)
+            if pref and isinstance(pref, (tuple, list)) and len(pref) == 2:
+                conv = list(pref[0])
+                ctrl = list(pref[1])
+        except Exception:
+            pass
+
     # Prefer response_dir if available (and no explicit groups combo selected)
     response_dir = getattr(config, "response_dir", "") or ""
     if not response_dir and not conv and not ctrl:
@@ -115,6 +124,8 @@ def _launch_site_viewer(
                         sel = getattr(parent, '_selected_response_matrix')
                         if sel in files:
                             selected_name = sel
+                    elif getattr(config, 'preferred_response_matrix', '') in files:
+                        selected_name = getattr(config, 'preferred_response_matrix')
                 except Exception:
                     pass
 
@@ -140,6 +151,11 @@ def _launch_site_viewer(
                         else:
                             ctrl.append(sp)
                 used_response_dir = True
+                if not getattr(config, 'preferred_response_matrix', ''):
+                    try:
+                        config.preferred_response_matrix = selected_name
+                    except Exception:
+                        pass
     except Exception:
         # Fall through to species groups parsing on error
         conv, ctrl, used_response_dir = [], [], False
@@ -164,6 +180,12 @@ def _launch_site_viewer(
                         conv.append(first_sp)
                     else:
                         ctrl.append(first_sp)
+                if getattr(config, 'preferred_groups_combo', None) is None:
+                    try:
+                        config.preferred_groups_combo = (list(conv), list(ctrl))
+                        config.preferred_response_matrix = ""
+                    except Exception:
+                        pass
             except Exception:
                 conv = []
                 ctrl = []
@@ -452,6 +474,8 @@ class GeneRanksDialog(QDialog):
 
         self.config = config
         self.sites_path = sites_path
+        self._selected_groups_combo = getattr(config, 'preferred_groups_combo', None)
+        self._selected_response_matrix = getattr(config, 'preferred_response_matrix', '')
 
         df = dataframe
 
@@ -560,6 +584,8 @@ class GeneRanksDialog(QDialog):
             if res:
                 try:
                     setattr(self, '_selected_groups_combo', res)
+                    self.config.preferred_groups_combo = res
+                    self.config.preferred_response_matrix = ""
                 except Exception:
                     pass
             return
@@ -648,6 +674,8 @@ class GeneRanksDialog(QDialog):
             selected = combo.currentText()
             try:
                 setattr(self, '_selected_response_matrix', selected)
+                self.config.preferred_response_matrix = selected
+                self.config.preferred_groups_combo = None
             except Exception:
                 pass
 
@@ -937,6 +965,8 @@ class FastScanResultsDialog(QDialog):
         self.setWindowTitle("Fast Scan Results")
         self.config = config
         self.outgroup = outgroup
+        self._selected_groups_combo = getattr(config, 'preferred_groups_combo', None)
+        self._selected_response_matrix = getattr(config, 'preferred_response_matrix', '')
         layout = QVBoxLayout(self)
 
         header = QHBoxLayout()
@@ -1155,6 +1185,8 @@ class FastScanResultsDialog(QDialog):
             if res:
                 try:
                     setattr(self, '_selected_groups_combo', res)
+                    self.config.preferred_groups_combo = res
+                    self.config.preferred_response_matrix = ""
                 except Exception:
                     pass
             return
@@ -1230,6 +1262,8 @@ class FastScanResultsDialog(QDialog):
                 selected = combo.currentText()
                 try:
                     setattr(self, '_selected_response_matrix', selected)
+                    self.config.preferred_response_matrix = selected
+                    self.config.preferred_groups_combo = None
                 except Exception:
                     pass
             return


### PR DESCRIPTION
## Summary
- add Site Viewer button on the input page that lets users pick an alignment and species combo
- remember the chosen species combo or response matrix for the session and reuse it across viewers
- reset remembered combo when the species groups file or response matrix directory changes

## Testing
- `flake8 --select=F --exclude additional_code .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c3865870ec8327909f605f8d8e49cf